### PR TITLE
OpenClaw integration: energy-aware API surface + docs + demo fixes

### DIFF
--- a/ENERGY_AWARENESS.md
+++ b/ENERGY_AWARENESS.md
@@ -821,19 +821,9 @@ npm run demo:coding -w packages/benchmarks
 Runs a real coding agent task in both modes with a live energy meter showing
 budget pressure, strategy activations, and model routing in real-time.
 
-Includes per-model energy efficiency reference data (tokens/joule):
-
-| Model | Tokens/Joule |
-|-------|-------------|
-| `Qwen/Qwen3.5-35B-A3B` | 27.51 |
-| `mistralai/Devstral-Small-2-24B-Instruct-2512` | 22.35 |
-| `Qwen/Qwen3.5-397B-A17B-FP8` | 1.03 |
-| `openai/gpt-oss-20b` | 0.50 |
-| `MiniMaxAI/MiniMax-M2.5` | 0.50 |
-| `moonshotai/Kimi-K2.5` | 0.21 |
-
-These are approximations from `portal.neuralwatt.com`. Prefer API-reported
-`energy_joules` when available.
+Energy consumption is reported from real API telemetry (`energy_joules` in the
+Neuralwatt SSE stream). If a run returns no energy data a warning is printed and
+that run is recorded as 0 J.
 
 ### Demo 2: HackerNews Energy-Aware Watcher
 

--- a/ENERGY_AWARENESS.md
+++ b/ENERGY_AWARENESS.md
@@ -1,87 +1,646 @@
 # Energy-Aware Mode
 
-This document defines the design contract for energy-aware operation in pi-mono, using Neuralwatt endpoints.
+This document is the implementation reference for energy-aware operation in
+pi-mono, using Neuralwatt endpoints.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Type System](#type-system)
+- [Provider Integration](#provider-integration)
+- [Policy Framework](#policy-framework)
+- [Agent Loop Integration](#agent-loop-integration)
+- [SDK Integration](#sdk-integration)
+- [Benchmark Harness](#benchmark-harness)
+- [Live Demos](#live-demos)
+- [Testing](#testing)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Downstream Integration (openclaw)](#downstream-integration-openclaw)
+
+---
 
 ## Overview
 
 pi-mono supports two runtime modes that can be compared head-to-head:
 
-- **Baseline Mode** — default behavior, no policy intervention, all model calls use full parameters
-- **Energy-Aware Mode** — a runtime policy observes energy consumption per call and adaptively reduces it without degrading task success rate
+- **Baseline Mode** — default behavior, no policy intervention, all model
+  calls use full parameters
+- **Energy-Aware Mode** — a runtime policy observes energy consumption per
+  call and adaptively reduces it without degrading task success rate
 
-Both modes use the **same Neuralwatt endpoint** (`https://api.neuralwatt.com/v1`). The only difference is the active `RuntimePolicy`.
+Both modes use the **same Neuralwatt endpoint** (`https://api.neuralwatt.com/v1`).
+The only difference is the active `RuntimePolicy`.
 
-## Metrics
+When no policy is configured, the agent loop behaves identically to upstream
+pi-mono — all energy features are opt-in.
 
-| Metric | Unit | Description |
-|--------|------|-------------|
-| energy/task | joules (J) | Total energy consumed to complete one benchmark task |
-| time/task | milliseconds (ms) | Wall-clock time to complete one benchmark task |
-| success rate | % | Fraction of tasks whose validator returns `passed: true` |
-| task score | 0–10 | Quality score from the task validator |
+---
 
-## Energy Data Source
+## Architecture
 
-Neuralwatt returns per-request energy data in the API response. The `EnergyUsage` fields are:
+Energy awareness is implemented across five layers, each in a separate package:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  packages/coding-agent   SDK layer                      │
+│  createAgentSession({ policy, budget, availableModels })│
+├─────────────────────────────────────────────────────────┤
+│  packages/agent          Agent + policy layer           │
+│  Agent class ──► agentLoop ──► beforeModelCall          │
+│                              ◄── afterModelCall         │
+│  policy/                                                │
+│    BaselinePolicy      (no-op, logs only)               │
+│    EnergyAwarePolicy   (5-strategy chain)               │
+├─────────────────────────────────────────────────────────┤
+│  packages/ai             Provider layer                 │
+│  streamSimpleOpenAICompletions()                        │
+│    └── extracts energy_joules/energy_kwh from response  │
+│    └── attaches EnergyUsage to AssistantMessage.energy  │
+├─────────────────────────────────────────────────────────┤
+│  packages/benchmarks     Benchmark layer                │
+│  Runner, tasks, demos, report generation                │
+└─────────────────────────────────────────────────────────┘
+```
+
+Data flows bottom-up:
+1. Provider extracts energy fields from LLM response
+2. Agent loop reads `AssistantMessage.energy` and feeds it to the policy
+3. Policy decides whether to intervene (reduce reasoning, cap tokens, route
+   to a cheaper model, compact context, or abort)
+4. Agent loop applies the decision to the next model call
+5. SDK exposes configuration to callers
+
+---
+
+## Type System
+
+### EnergyUsage (`packages/ai/src/types.ts`)
+
+Per-request energy data returned by providers that support it.
 
 ```typescript
 interface EnergyUsage {
-  energy_joules: number;   // energy consumed for this request
-  energy_kwh: number;      // same value in kWh
-  duration_seconds: number; // server-side processing time
+   energy_joules: number;   // energy consumed for this request
+   energy_kwh: number;      // same value in kWh (1 kWh = 3,600,000 J)
+   duration_seconds: number; // server-side processing time
 }
 ```
 
-These fields are attached to every `AssistantMessage` returned through the Neuralwatt provider as `message.energy`.
+Attached to `AssistantMessage` as an optional field:
 
-## Policy Architecture
+```typescript
+interface AssistantMessage {
+   // ... existing fields ...
+   energy?: EnergyUsage;
+}
+```
 
-### RuntimePolicy interface
+### buildAssistantMessage() (`packages/ai/src/types.ts`)
+
+Factory function that constructs `AssistantMessage` with all current fields.
+Downstream consumers should use this instead of object literals to avoid
+silently dropping optional fields like `energy` as the type evolves.
+
+```typescript
+function buildAssistantMessage(params: {
+   content: AssistantMessage["content"];
+   api: Api;
+   provider: Provider;
+   model: string;
+   usage: Usage;
+   stopReason: StopReason;
+   energy?: EnergyUsage;
+   errorMessage?: string;
+   timestamp?: number;
+}): AssistantMessage;
+```
+
+### TelemetryRecord (`packages/ai/src/energy-types.ts`)
+
+Structured telemetry schema for per-call logging. One JSON object per line
+(JSONL format).
+
+```typescript
+interface TelemetryRecord {
+   task_id: string;
+   run_id: string;
+   step_id: string;
+   model: string;
+   provider: string;
+   tokens: { input: number; output: number; total: number };
+   latency_ms: number;
+   energy_joules: number;
+   energy_kwh: number;
+   timestamp: number;
+}
+```
+
+**Utility functions** (all in `packages/ai/src/energy-types.ts`):
+
+| Function | Description |
+|----------|-------------|
+| `buildTelemetryRecord(input: TelemetryInput)` | Convert model call results to a `TelemetryRecord`. Defaults missing energy to 0. |
+| `serializeTelemetryRecord(record)` | Serialize to a single JSONL line (no trailing newline) |
+| `parseTelemetryRecord(line)` | Parse and validate a single JSONL line. Throws on invalid/missing fields. |
+| `appendTelemetryLine(lines, record)` | Append a serialized record to an array |
+| `parseTelemetryLines(content)` | Parse multi-line JSONL content, skipping empty lines |
+
+`TelemetryInput` is the input shape for `buildTelemetryRecord()`:
+
+```typescript
+interface TelemetryInput {
+   task_id: string;
+   run_id: string;
+   step_id: string;
+   model: string;
+   provider: string;
+   usage: Usage;
+   energy?: EnergyUsage;
+   latency_ms: number;
+   timestamp?: number; // defaults to Date.now()
+}
+```
+
+### Policy Types (`packages/agent/src/policy/types.ts`)
+
+```typescript
+interface EnergyBudget {
+   energy_budget_joules?: number;
+   time_budget_ms?: number;
+}
+
+interface PolicyContext {
+   taskId?: string;
+   turnNumber: number;
+   model: Model<any>;
+   availableModels: Model<any>[]; // sorted by cost.output ascending
+   budget: EnergyBudget;
+   consumedEnergy: number;        // joules consumed so far
+   consumedTime: number;          // milliseconds elapsed since run start
+   messageCount: number;
+   estimatedInputTokens: number;  // from last AssistantMessage.usage.totalTokens
+}
+
+interface PolicyDecision {
+   model?: Model<any>;       // override model for this call
+   maxTokens?: number;       // override maxTokens
+   reasoning?: ThinkingLevel; // override reasoning level
+   shouldCompact?: boolean;  // request context compaction
+   abort?: boolean;          // stop the agent loop
+   reason?: string;          // human-readable explanation
+}
+
+interface UsageWithEnergy {
+   input: number;
+   output: number;
+   totalTokens: number;
+   cost: { total: number };
+   energy_joules?: number;
+   energy_kwh?: number;
+}
+
+interface RuntimePolicy {
+   name: string;
+   beforeModelCall(ctx: PolicyContext): PolicyDecision;
+   afterModelCall(ctx: PolicyContext, usage: UsageWithEnergy): void;
+}
+```
+
+All policy types are exported from `@mariozechner/pi-agent-core` and
+re-exported from `@mariozechner/pi-coding-agent`.
+
+---
+
+## Provider Integration
+
+### Neuralwatt Provider
+
+Neuralwatt is registered as an OpenAI-compatible provider.
+
+**Configuration:**
+- Provider name: `"neuralwatt"`
+- API: `openai-completions`
+- Base URL: `https://api.neuralwatt.com/v1`
+- API key env var: `NEURALWATT_API_KEY`
+- Compat: `supportsStore: false`, `supportsDeveloperRole: false`,
+  `supportsReasoningEffort: false`, `maxTokensField: "max_tokens"`
+
+**Registered Models** (in `packages/ai/src/models.generated.ts`):
+
+| Model ID | Context Window | Max Output | Capabilities |
+|----------|---------------|------------|--------------|
+| `mistralai/Devstral-Small-2-24B-Instruct-2512` | 262,144 | 16,384 | tool_calling |
+| `openai/gpt-oss-20b` | 16,384 | 4,096 | tool_calling |
+| `moonshotai/Kimi-K2.5` | 262,144 | — | tool_calling |
+| `MiniMaxAI/MiniMax-M2.5` | — | — | tool_calling |
+| `Qwen/Qwen3.5-397B-A17B-FP8` | 262,144 | — | tool_calling |
+| `Qwen/Qwen3.5-35B-A3B` | — | — | tool_calling |
+| `zai-org/GLM-5-FP8` | — | — | tool_calling |
+
+All models include per-token pricing from `portal.neuralwatt.com`.
+
+### Energy Data Extraction (`packages/ai/src/providers/openai-completions.ts`)
+
+Energy fields are parsed from the streaming response's `usage` object at
+lines 133-145 of `openai-completions.ts`:
+
+```typescript
+// Parse energy telemetry from Neuralwatt (or any compatible provider)
+const usageAny = chunk.usage as unknown as Record<string, unknown>;
+const energyJoules =
+   typeof usageAny.energy_joules === "number" ? usageAny.energy_joules : undefined;
+const energyKwh =
+   typeof usageAny.energy_kwh === "number" ? usageAny.energy_kwh : undefined;
+const durationSeconds =
+   typeof usageAny.duration_seconds === "number" ? usageAny.duration_seconds : undefined;
+
+if (energyJoules !== undefined || energyKwh !== undefined) {
+   output.energy = {
+      energy_joules: energyJoules ?? (energyKwh! * 3_600_000),
+      energy_kwh: energyKwh ?? (energyJoules! / 3_600_000),
+      duration_seconds: durationSeconds ?? 0,
+   };
+}
+```
+
+**Key behaviors:**
+- Only numeric values are accepted (type guards reject strings, nulls, etc.)
+- At least one of `energy_joules` or `energy_kwh` must be present to populate
+  `output.energy`
+- If only one field is provided, the other is computed via unit conversion
+  (`1 kWh = 3,600,000 J`)
+- `duration_seconds` defaults to 0 if not provided
+- When neither energy field is present, `AssistantMessage.energy` remains
+  `undefined` — graceful degradation, no crashes
+- This works with **any** OpenAI-compatible provider that includes energy
+  fields in the usage response, not just Neuralwatt
+
+---
+
+## Policy Framework
+
+### RuntimePolicy Interface
+
+All policies implement the `RuntimePolicy` interface:
 
 ```typescript
 interface RuntimePolicy {
-  name: string;
-  beforeModelCall(ctx: PolicyContext): PolicyDecision;
-  afterModelCall(ctx: PolicyContext, usage: UsageWithEnergy): void;
+   name: string;
+   beforeModelCall(ctx: PolicyContext): PolicyDecision;
+   afterModelCall(ctx: PolicyContext, usage: UsageWithEnergy): void;
 }
 ```
 
-- `beforeModelCall` is called before each LLM call and can override model, maxTokens, reasoning level, or trigger compaction/abort
-- `afterModelCall` is called after each LLM call completes and updates the policy's internal state with energy consumed
+- `beforeModelCall` is called before each LLM call. Returns a `PolicyDecision`
+  that can override model, maxTokens, reasoning level, or trigger
+  compaction/abort.
+- `afterModelCall` is called after each LLM call completes. Receives the
+  actual usage (including energy) for the policy to update its internal state.
 
-### BaselinePolicy
+### BaselinePolicy (`packages/agent/src/policy/baseline-policy.ts`)
 
-No-op policy. `beforeModelCall` returns an empty `PolicyDecision`. `afterModelCall` logs telemetry only. Used to establish baseline measurements.
+No-op policy for establishing baseline measurements.
 
-### EnergyAwarePolicy
+- **Name:** `"baseline"`
+- `beforeModelCall()` — always returns `{}` (no interventions)
+- `afterModelCall()` — logs `{ ctx, usage }` to internal `_log` array
+- `log` getter — returns `ReadonlyArray<{ ctx: PolicyContext; usage: UsageWithEnergy }>`
 
-Adaptive policy with a five-stage strategy chain, activated in order as budget pressure increases:
+Use this as the control group when benchmarking.
 
-| Stage | Trigger | Action |
-|-------|---------|--------|
-| 1. Reasoning reduction | pressure > 30% | Reduce reasoning level: high → medium → low → off |
-| 2. Token reduction | pressure > 50% | Reduce maxTokens by up to 40% |
-| 3. Model routing | pressure > 70% | Switch to cheapest available model supporting required capabilities |
-| 4. Context compaction | pressure > 50% AND tokens > 60% of context window | Trigger context compaction |
-| 5. Budget exhaustion | pressure ≥ 100% | Abort with reason message |
+### EnergyAwarePolicy (`packages/agent/src/policy/energy-aware-policy.ts`)
 
-**Budget pressure** = `consumedEnergy / energy_budget_joules`
+Adaptive policy with a five-stage strategy chain. Strategies are evaluated
+in order on every turn; multiple can fire simultaneously.
 
-Falls back to time-based pressure (`consumedTime / time_budget_ms`) if no energy budget is set.
-Returns 0 (no intervention) if neither budget is set.
+**Budget pressure** drives all decisions:
 
-Every policy decision includes a human-readable `reason` string for observability.
+```
+pressure = consumedEnergy / energy_budget_joules
+```
 
-## Acceptance Criteria
+Falls back to time-based pressure (`consumedTime / time_budget_ms`) if no
+energy budget is set. Returns 0 (no intervention) if neither budget is set.
 
-Energy-aware mode must:
-- Achieve **≥20% energy reduction** compared to baseline across the benchmark task suite
-- Maintain **≤5% success rate degradation** compared to baseline
-- Never crash when energy telemetry is missing (graceful fallback to baseline behavior)
+#### Strategy 1: Reasoning Reduction (pressure > 30%)
+
+Scales reasoning level down as pressure increases. Only applies to models
+with `reasoning: true`.
+
+| Pressure | Reasoning Level |
+|----------|----------------|
+| > 30% | `"medium"` |
+| > 60% | `"low"` |
+| > 80% | `"minimal"` |
+
+Available levels: `["high", "medium", "low", "minimal"]`
+
+#### Strategy 2: Token Limit Reduction (pressure > 50%)
+
+Reduces `maxTokens` by up to 40%, scaling linearly with pressure.
+
+```
+reductionFactor = min(0.4, ((pressure - 0.5) / 0.5) * 0.4)
+newMaxTokens = floor(model.maxTokens * (1 - reductionFactor))
+```
+
+| Pressure | Reduction |
+|----------|-----------|
+| 50% | 0% |
+| 75% | 20% |
+| 100% | 40% (capped) |
+
+#### Strategy 3: Model Routing (pressure > 70%)
+
+Routes to the cheapest model from `availableModels` that supports the
+required capabilities.
+
+**Capability checks:**
+- If current model has `reasoning: true`, candidate must too
+- If current model has `"image"` in `input`, candidate must too
+
+**Cost check:** Only routes if `candidate.cost.output < current.cost.output`
+
+**Selection:** `availableModels` must be pre-sorted by `cost.output`
+ascending. The policy picks the first candidate that meets all requirements.
+
+#### Strategy 4: Context Compaction (pressure > 50% AND estimatedInputTokens > 60% of contextWindow)
+
+Sets `decision.shouldCompact = true` when the context is growing too large
+under budget pressure. The agent loop invokes the `onCompact` callback if
+one is configured.
+
+The context window check uses the effective model (i.e. the routed model
+if Strategy 3 fired, otherwise the current model).
+
+#### Strategy 5: Budget Exhaustion (pressure >= 100%)
+
+Short-circuits all other strategies. Sets `decision.abort = true` with a
+reason message. The agent loop creates a synthetic abort message and stops.
+
+#### Observability
+
+Every decision includes a human-readable `reason` string. Examples:
+
+```
+"reasoning: high -> medium (pressure 45%)"
+"maxTokens: 16384 -> 11469 (-30%, pressure 75%)"
+"model: Qwen3.5-397B -> Devstral-24B (cost 1.327 -> 0.15, pressure 82%)"
+"budget exhausted: pressure 105%"
+```
+
+The `afterModelCall` hook logs `{ ctx, usage }` to an internal `_log` array
+accessible via the `log` getter.
+
+---
+
+## Agent Loop Integration
+
+### PolicyState (`packages/agent/src/agent-loop.ts`)
+
+Mutable state tracked across the agent loop for policy context:
+
+```typescript
+interface PolicyState {
+   turnNumber: number;
+   consumedEnergy: number;       // cumulative joules
+   consumedTime: number;         // milliseconds since run start
+   estimatedInputTokens: number; // from last AssistantMessage.usage.totalTokens
+   startTime: number;            // Date.now() at loop start
+}
+```
+
+### Before Model Call
+
+On each turn:
+1. Increment `turnNumber`, update `consumedTime`
+2. Build `PolicyContext` from current state
+3. Call `policy.beforeModelCall(ctx)` if configured
+4. **Abort handling:** If `decision.abort`, emit a synthetic "Budget exhausted"
+   `AssistantMessage` with `stopReason: "aborted"` and end the loop
+5. **Compaction:** If `decision.shouldCompact && config.onCompact`, invoke
+   `config.onCompact(currentContext.messages)` and replace the context
+6. **Model override:** Use `decision.model` if set, otherwise `config.model`
+7. **Options override:** Apply `decision.maxTokens` and `decision.reasoning`
+   to the stream options
+8. **API key resolution:** Resolve API key for the effective model's provider
+   (important when routing to a different provider)
+
+### After Model Call
+
+After the LLM response completes:
+1. Extract `energy` from `AssistantMessage.energy`
+2. Build `UsageWithEnergy` from usage + energy fields
+3. Accumulate `energy_joules` to `policyState.consumedEnergy`
+4. Update `estimatedInputTokens` from `usage.totalTokens`
+5. Call `policy.afterModelCall(ctx, usageWithEnergy)`
+
+### AgentLoopConfig Fields (`packages/agent/src/types.ts`)
+
+```typescript
+interface AgentLoopConfig extends SimpleStreamOptions {
+   // ... existing fields ...
+
+   /** Optional runtime policy for energy-aware budgeting. */
+   policy?: RuntimePolicy;
+
+   /** Models available for policy-driven routing, sorted by cost.output ascending. */
+   availableModels?: Model<any>[];
+
+   /** Energy/time budget for policy-driven enforcement. */
+   budget?: EnergyBudget;
+
+   /** Called when the policy requests context compaction. */
+   onCompact?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
+}
+```
+
+---
+
+## SDK Integration
+
+### Agent Class (`packages/agent/src/agent.ts`)
+
+The high-level `Agent` class accepts policy configuration through `AgentOptions`
+and forwards it to the agent loop:
+
+```typescript
+interface AgentOptions {
+   // ... existing fields ...
+
+   policy?: RuntimePolicy;
+   availableModels?: Model<any>[];
+   budget?: EnergyBudget;
+   onCompact?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
+}
+```
+
+Runtime accessors allow mid-session changes:
+
+```typescript
+agent.policy = new EnergyAwarePolicy();
+agent.availableModels = neuralwattModels;
+agent.budget = { energy_budget_joules: 100 };
+```
+
+### createAgentSession (`packages/coding-agent/src/core/sdk.ts`)
+
+The top-level SDK function accepts and forwards policy config:
+
+```typescript
+interface CreateAgentSessionOptions {
+   // ... existing fields ...
+
+   policy?: RuntimePolicy;
+   availableModels?: Model<any>[];
+   budget?: EnergyBudget;
+   onCompact?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
+}
+```
+
+**Re-exports** from pi-coding-agent (so consumers can import from one place):
+
+```typescript
+export type { EnergyBudget, RuntimePolicy } from "@mariozechner/pi-agent-core";
+export type { EnergyUsage } from "@mariozechner/pi-ai";
+```
+
+### Usage Example
+
+```typescript
+import {
+   createAgentSession,
+   type EnergyBudget,
+} from "@mariozechner/pi-coding-agent";
+import { EnergyAwarePolicy } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+
+// Gather Neuralwatt models sorted by output cost
+const availableModels = [
+   getModel("neuralwatt", "Qwen/Qwen3.5-35B-A3B"),
+   getModel("neuralwatt", "mistralai/Devstral-Small-2-24B-Instruct-2512"),
+   getModel("neuralwatt", "Qwen/Qwen3.5-397B-A17B-FP8"),
+].sort((a, b) => a.cost.output - b.cost.output);
+
+const { session } = await createAgentSession({
+   model: availableModels[0], // start with cheapest
+   policy: new EnergyAwarePolicy(),
+   availableModels,
+   budget: { energy_budget_joules: 50 },
+   onCompact: async (messages) => {
+      // your compaction logic here
+      return messages.slice(-10);
+   },
+});
+```
+
+---
 
 ## Benchmark Harness
 
-The `packages/benchmarks` package provides:
+The `packages/benchmarks` package provides a mock-based benchmark runner
+for comparing baseline vs energy-aware modes without live API calls.
+
+### Types (`packages/benchmarks/src/types.ts`)
+
+```typescript
+/** Task definition */
+interface BenchmarkTask {
+   id: string;
+   name: string;
+   description: string;
+   prompt: string;
+   tools?: AgentTool[];
+   maxTurns: number;
+   mockTurnUsage?: MockTurnUsage[]; // per-turn overrides for mocked runs
+   validator: (
+      records: TelemetryRecord[],
+      decisions: PolicyDecisionLog[],
+   ) => { passed: boolean; score: number; reason: string };
+}
+
+/** Aggregated result for a single task run */
+interface TaskResult {
+   task_id: string;
+   run_id: string;
+   mode: "baseline" | "energy-aware";
+   passed: boolean;
+   score: number;
+   time_ms: number;
+   energy_joules: number;
+   tokens_total: number;
+   turns: number;
+   policy_decisions: PolicyDecisionLog[];
+}
+
+/** Log entry for a single policy decision */
+interface PolicyDecisionLog {
+   turn: number;
+   pressure: number;
+   reason: string;
+   actions: string[]; // e.g. ["route:model-id", "reasoning:medium", "compact", "abort"]
+}
+
+/** Side-by-side comparison for one task */
+interface TaskComparison {
+   task_id: string;
+   task_name: string;
+   baseline: TaskResult;
+   energy_aware: TaskResult;
+   energy_savings_pct: number;
+   time_delta_pct: number;
+}
+
+/** Full benchmark report */
+interface BenchmarkReport {
+   run_date: string;
+   baseline_run_id: string;
+   energy_aware_run_id: string;
+   tasks: TaskComparison[];
+   aggregate: {
+      mean_energy_savings_pct: number;
+      mean_time_delta_pct: number;
+      baseline_success_rate: number;
+      energy_aware_success_rate: number;
+   };
+}
+
+/** Runner configuration */
+interface RunConfig {
+   runId?: string;
+   mode: "baseline" | "energy-aware";
+   model: Model<Api>;
+   availableModels: Model<Api>[];
+   budget: EnergyBudget;
+   policy?: RuntimePolicy;
+}
+```
+
+### Runner (`packages/benchmarks/src/runner.ts`)
+
+The runner simulates agent loop turns using mocked usage data:
+
+1. For each turn, builds a `PolicyContext` with current state
+2. Calls `policy.beforeModelCall(ctx)` — records the decision
+3. Checks for abort
+4. Simulates model call using `MockTurnUsage` data
+5. Calls `policy.afterModelCall(ctx, usage)`
+6. Accumulates energy and tokens
+7. After all turns, calls the task's `validator` with collected telemetry
+
+Default mock usage per turn: 500 input tokens, 200 output tokens,
+0.5 joules, 100ms latency.
+
+### Output Files
+
+| File | Format | Description |
+|------|--------|-------------|
+| `results.jsonl` | JSONL | Per-call telemetry records |
+| `summary.csv` | CSV | Per-task aggregated results |
+| `report.md` | Markdown | Human-readable comparison report with verdict |
+
+### Scripts
 
 ```bash
 # Run baseline only
@@ -94,21 +653,110 @@ cd packages/benchmarks && node dist/cli.js run --mode energy-aware
 cd packages/benchmarks && node dist/cli.js run --compare
 ```
 
-Output files:
-- `results.jsonl` — per-call telemetry records
-- `summary.csv` — per-task aggregated results
-- `report.md` — human-readable comparison report with verdict
+---
 
 ## Live Demos
 
 ### Demo 1: Coding Agent Energy Challenge
+
 ```bash
 npm run demo:coding -w packages/benchmarks
 ```
-Runs a real coding agent task in both modes sequentially with a live energy meter and final scorecard.
+
+Runs a real coding agent task in both modes with a live energy meter showing
+budget pressure, strategy activations, and model routing in real-time.
+
+Includes per-model energy efficiency reference data (tokens/joule):
+
+| Model | Tokens/Joule |
+|-------|-------------|
+| `Qwen/Qwen3.5-35B-A3B` | 27.51 |
+| `mistralai/Devstral-Small-2-24B-Instruct-2512` | 22.35 |
+| `Qwen/Qwen3.5-397B-A17B-FP8` | 1.03 |
+| `openai/gpt-oss-20b` | 0.50 |
+| `MiniMaxAI/MiniMax-M2.5` | 0.50 |
+| `moonshotai/Kimi-K2.5` | 0.21 |
+
+These are approximations from `portal.neuralwatt.com`. Prefer API-reported
+`energy_joules` when available.
 
 ### Demo 2: HackerNews Energy-Aware Watcher
+
 ```bash
 npm run demo:hn -w packages/benchmarks
 ```
-Runs a continuous HackerNews relevance monitor for AI-related topics, comparing energy consumption between modes over 3 minutes.
+
+Runs a continuous HackerNews relevance monitor for AI-related topics,
+comparing energy consumption between modes over 3 minutes.
+
+---
+
+## Testing
+
+### Energy Telemetry Tests (`packages/ai/test/energy-telemetry.test.ts`)
+
+- `buildTelemetryRecord()` — complete data, missing energy (defaults to 0),
+  timestamp fallback to `Date.now()`
+- Serialization/deserialization round-trip fidelity
+- JSONL batch parsing with empty line skipping
+- Schema contract validation — all required fields present
+
+### Energy Metrics Tests (`packages/ai/test/energy-metrics.test.ts`)
+
+- Parsing `energy_joules` and `energy_kwh` from mock OpenAI-compatible
+  streaming responses
+- Unit conversion: `joules / 3,600,000 = kWh` and reverse
+- Graceful handling: `energy` is `undefined` when no fields present
+- Non-numeric field rejection (strings, nulls)
+- Provider-agnostic: any OpenAI-compatible provider can include energy fields
+
+### BaselinePolicy Tests (`packages/agent/test/policy/baseline-policy.test.ts`)
+
+- `beforeModelCall()` always returns empty decision
+- `afterModelCall()` logs telemetry correctly
+- Accumulation of multiple calls
+- Identical agent behavior to no-policy execution
+- Graceful handling of missing energy data
+
+### EnergyAwarePolicy Tests (`packages/agent/test/policy/energy-aware-policy.test.ts`)
+
+- Pressure calculation: energy vs time budget priority
+- Strategy 1: reasoning reduction at 30%, 60%, 80% thresholds
+- Strategy 2: token reduction linear scaling, 40% cap
+- Strategy 3: model routing with capability checks (reasoning, image),
+  cost filtering, sorted selection
+- Strategy 4: context compaction threshold (60% of context window)
+- Strategy 5: budget exhaustion abort at 100%
+
+### Policy Hooks Integration Tests (`packages/agent/test/policy/policy-hooks.test.ts`)
+
+- Agent loop + policy interaction with mock policies
+- Abort handling: agent stops when policy returns `abort: true`
+- Decision application: model, maxTokens, reasoning overrides applied
+- State updates: energy accumulation, turn counting
+
+---
+
+## Acceptance Criteria
+
+Energy-aware mode must:
+- Achieve **>=20% energy reduction** compared to baseline across the
+  benchmark task suite
+- Maintain **<=5% success rate degradation** compared to baseline
+- Never crash when energy telemetry is missing (graceful fallback to
+  baseline behavior)
+
+---
+
+## Downstream Integration (openclaw)
+
+See [OPENCLAW_INTEGRATION.md](OPENCLAW_INTEGRATION.md) for the full
+integration plan. All pi-mono preparatory work is complete. The remaining
+work is on the openclaw side:
+
+1. Fix `buildAssistantMessage()` in openclaw to include the `energy` field
+2. Fix `normalizeUsage()` to propagate energy data in the result pipeline
+3. Wire `policy`, `availableModels`, `budget` through session creation
+4. Connect `onCompact` to openclaw's existing compaction extension
+5. Add telemetry persistence
+6. Re-export energy types from the plugin SDK

--- a/ENERGY_AWARENESS.md
+++ b/ENERGY_AWARENESS.md
@@ -56,9 +56,11 @@ where it matters and conserve where it doesn't.
 - **Adaptive strategy chain** — as budget pressure rises, the policy
   progressively reduces reasoning depth, caps output tokens, routes to
   cheaper models, compacts context, and ultimately aborts if the budget is
-  exhausted
+  exhausted. Can leverage budget as informational only via config.
 - **Model routing** — automatically switches to the most cost-effective model
-  that still meets capability requirements (reasoning, image support)
+  that still meets capability requirements (reasoning, image support) while 
+  aggressively upgrading model capability on subtask failure to ensure problem
+  convergence while maintaining efficiency.
 - **Structured telemetry** — JSONL telemetry records for every call, ready
   for dashboards, auditing, or billing
 - **Benchmark harness** — compare baseline vs energy-aware mode side-by-side
@@ -68,7 +70,7 @@ where it matters and conserve where it doesn't.
 
 | Metric | Target | How |
 |--------|--------|-----|
-| Energy per task | **>=20% reduction** vs baseline | Reasoning reduction, token capping, model routing |
+| Energy per task | **>=80% reduction** vs baseline | Reasoning reduction, token capping, model routing |
 | Success rate | **<=5% degradation** vs baseline | Strategies are progressive — light interventions first |
 | Cost per task | Proportional to energy savings | Cheaper models consume less energy and cost less |
 | Context efficiency | Reduced bloat under pressure | Compaction triggered when context exceeds 60% of window |
@@ -80,6 +82,8 @@ most expensive model. Energy-aware mode uses the full budget where it counts
 (simple responses, status checks).
 
 ### Quick Integration Guide
+
+How to quickly extend the agent capabilities of **Pi** dependent code to leverage these capabilities
 
 **Step 1: Set your API key**
 
@@ -891,7 +895,7 @@ comparing energy consumption between modes over 3 minutes.
 ## Acceptance Criteria
 
 Energy-aware mode must:
-- Achieve **>=20% energy reduction** compared to baseline across the
+- Achieve **>=80% energy reduction** compared to baseline across the
   benchmark task suite
 - Maintain **<=5% success rate degradation** compared to baseline
 - Never crash when energy telemetry is missing (graceful fallback to

--- a/ENERGY_AWARENESS.md
+++ b/ENERGY_AWARENESS.md
@@ -6,6 +6,7 @@ pi-mono, using Neuralwatt endpoints.
 ## Table of Contents
 
 - [Overview](#overview)
+- [Quickstart](#quickstart)
 - [Architecture](#architecture)
 - [Type System](#type-system)
 - [Provider Integration](#provider-integration)
@@ -34,6 +35,156 @@ The only difference is the active `RuntimePolicy`.
 
 When no policy is configured, the agent loop behaves identically to upstream
 pi-mono — all energy features are opt-in.
+
+---
+
+## Quickstart
+
+### What It Does
+
+Energy-aware mode gives AI agents a **energy budget** and a policy that
+automatically adapts behavior to stay within it. Instead of every model call
+using maximum parameters regardless of cost, the agent learns to spend energy
+where it matters and conserve where it doesn't.
+
+**Capabilities at a glance:**
+
+- **Per-request energy telemetry** — every LLM call reports joules consumed,
+  kWh, and server-side duration, attached directly to the response message
+- **Pluggable runtime policies** — swap between baseline (no intervention)
+  and energy-aware (adaptive 5-strategy chain) with a single config change
+- **Adaptive strategy chain** — as budget pressure rises, the policy
+  progressively reduces reasoning depth, caps output tokens, routes to
+  cheaper models, compacts context, and ultimately aborts if the budget is
+  exhausted
+- **Model routing** — automatically switches to the most cost-effective model
+  that still meets capability requirements (reasoning, image support)
+- **Structured telemetry** — JSONL telemetry records for every call, ready
+  for dashboards, auditing, or billing
+- **Benchmark harness** — compare baseline vs energy-aware mode side-by-side
+  with automated scoring and reporting
+
+### Potential Impact
+
+| Metric | Target | How |
+|--------|--------|-----|
+| Energy per task | **>=20% reduction** vs baseline | Reasoning reduction, token capping, model routing |
+| Success rate | **<=5% degradation** vs baseline | Strategies are progressive — light interventions first |
+| Cost per task | Proportional to energy savings | Cheaper models consume less energy and cost less |
+| Context efficiency | Reduced bloat under pressure | Compaction triggered when context exceeds 60% of window |
+| Observability | Full visibility into every decision | Human-readable reasons on every policy decision, JSONL telemetry |
+
+The key insight is that most agent turns don't need maximum reasoning or the
+most expensive model. Energy-aware mode uses the full budget where it counts
+(complex reasoning, tool orchestration) and conserves on routine turns
+(simple responses, status checks).
+
+### Quick Integration Guide
+
+**Step 1: Set your API key**
+
+```bash
+export NEURALWATT_API_KEY="your-key-here"
+```
+
+**Step 2: Create an energy-aware session** (3 lines of config)
+
+```typescript
+import { createAgentSession } from "@mariozechner/pi-coding-agent";
+import { EnergyAwarePolicy } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+
+const { session } = await createAgentSession({
+   model: getModel("neuralwatt", "mistralai/Devstral-Small-2-24B-Instruct-2512"),
+   policy: new EnergyAwarePolicy(),
+   budget: { energy_budget_joules: 50 },
+   availableModels: [
+      getModel("neuralwatt", "Qwen/Qwen3.5-35B-A3B"),        // cheapest
+      getModel("neuralwatt", "mistralai/Devstral-Small-2-24B-Instruct-2512"),
+      getModel("neuralwatt", "Qwen/Qwen3.5-397B-A17B-FP8"),  // most capable
+   ],
+});
+```
+
+That's it. The policy handles everything automatically:
+- Under 30% budget used: no intervention, full performance
+- 30-50%: reasoning depth reduced
+- 50-70%: output tokens capped, context compacted if bloated
+- 70-100%: routed to cheaper model
+- 100%+: agent stops with a clear reason
+
+**Step 3: Read energy data from responses** (optional)
+
+```typescript
+// After any agent interaction, energy is on the assistant message
+const lastMessage = session.agent.state.messages.at(-1);
+if (lastMessage?.role === "assistant" && lastMessage.energy) {
+   console.log(`Energy: ${lastMessage.energy.energy_joules.toFixed(2)} J`);
+   console.log(`Duration: ${lastMessage.energy.duration_seconds.toFixed(2)} s`);
+}
+```
+
+**Step 4: Run benchmarks** (optional)
+
+```bash
+# Compare both modes
+cd packages/benchmarks && node dist/cli.js run --compare
+
+# Live demo with energy meter
+npm run demo:coding -w packages/benchmarks
+```
+
+### Without the SDK
+
+If you're using the `Agent` class directly instead of `createAgentSession`:
+
+```typescript
+import { Agent, EnergyAwarePolicy } from "@mariozechner/pi-agent-core";
+
+const agent = new Agent({
+   initialState: { model, thinkingLevel: "high", ... },
+   policy: new EnergyAwarePolicy(),
+   availableModels: neuralwattModels,
+   budget: { energy_budget_joules: 100 },
+});
+```
+
+Or at the lowest level with `agentLoop()`:
+
+```typescript
+import { agentLoop } from "@mariozechner/pi-agent-core";
+
+const stream = agentLoop(prompts, context, {
+   model,
+   policy: new EnergyAwarePolicy(),
+   availableModels: neuralwattModels,
+   budget: { energy_budget_joules: 100 },
+   onCompact: async (messages) => yourCompactionLogic(messages),
+   convertToLlm: yourConverter,
+});
+```
+
+### Custom Policies
+
+Implement `RuntimePolicy` to create your own policy:
+
+```typescript
+import type { RuntimePolicy, PolicyContext, PolicyDecision, UsageWithEnergy } from "@mariozechner/pi-agent-core";
+
+const myPolicy: RuntimePolicy = {
+   name: "my-custom-policy",
+   beforeModelCall(ctx: PolicyContext): PolicyDecision {
+      // your logic — return {} for no intervention
+      if (ctx.consumedEnergy > 75) {
+         return { abort: true, reason: "Custom limit reached" };
+      }
+      return {};
+   },
+   afterModelCall(ctx: PolicyContext, usage: UsageWithEnergy): void {
+      // log, track, alert — whatever you need
+   },
+};
+```
 
 ---
 

--- a/OPENCLAW_INTEGRATION.md
+++ b/OPENCLAW_INTEGRATION.md
@@ -1,7 +1,7 @@
 # OpenClaw Integration: Energy Awareness
 
 This document tracks the work needed to bring energy awareness features from
-`energy-aware-pi-mono` into the [openclaw](~/dev/openclaw) project.
+`energy-aware-pi-mono` into the `openclaw` project.
 
 ## Background
 

--- a/OPENCLAW_INTEGRATION.md
+++ b/OPENCLAW_INTEGRATION.md
@@ -11,22 +11,43 @@ openclaw depends on 4 pi-mono packages (`@mariozechner/pi-ai`,
 
 All energy-aware changes are additive and opt-in — no existing APIs were broken.
 However, openclaw's internal patterns create friction that must be addressed on
-**both** sides.
+the **openclaw** side. All pi-mono preparatory work is complete.
 
 ---
 
-## Critical Issues (must fix before integration)
+## Pi-mono Preparatory Work (all complete)
 
-### 1. `buildAssistantMessage()` drops the `energy` field
+| Task | Description | Status |
+|------|-------------|--------|
+| P1 | `buildAssistantMessage()` factory in pi-ai — constructs AssistantMessage with all fields including `energy` | Done |
+| P2 | `createAgentSession` in pi-coding-agent accepts `policy`, `availableModels`, `budget`, `onCompact` and forwards to Agent | Done |
+| P3 | `onCompact` callback on `AgentLoopConfig` — agent loop invokes it when policy sets `shouldCompact: true` | Done |
+| P4 | Energy types exported from package entry points (`EnergyUsage`, `EnergyBudget`, `RuntimePolicy`, etc.) | Done |
+| P5 | CHANGELOG entries documenting `energy` passthrough requirement for downstream consumers | Done |
+| P6 | `Agent` class accepts and forwards `policy`, `availableModels`, `budget`, `onCompact` via `AgentOptions` + runtime accessors | Done |
+| P7 | pi-coding-agent re-exports `EnergyBudget`, `RuntimePolicy`, `EnergyUsage` so openclaw can import from a single package | Done |
+| P8 | Fixed pre-existing type errors (openai SDK `phase` field, missing `extract-zip` types) so `npm run check` passes clean | Done |
+
+---
+
+## Remaining Work (openclaw side)
+
+### Critical — must fix for energy data to flow
+
+#### 1. `buildAssistantMessage()` drops the `energy` field
 
 **Where:** `openclaw/src/agents/stream-message-shared.ts`
 
 openclaw's `buildAssistantMessage()` constructs a new `AssistantMessage` with
-explicit fields and does **not** pass through unknown properties. The `energy?:
-EnergyUsage` field added to `AssistantMessage` in pi-ai is silently discarded.
+explicit fields and does **not** pass through the `energy` property. The
+`energy?: EnergyUsage` field added to `AssistantMessage` in pi-ai is silently
+discarded.
 
-**Fix (openclaw side):** Add `energy` to `buildAssistantMessage()`:
+**Fix:** Add `energy` to the params type and the returned object. Or switch to
+using `buildAssistantMessage()` from `@mariozechner/pi-ai` (exported as P1).
+
 ```typescript
+// In stream-message-shared.ts buildAssistantMessage():
 return {
   role: "assistant",
   content: params.content,
@@ -35,56 +56,48 @@ return {
   provider: params.model.provider,
   model: params.model.id,
   usage: params.usage,
-  energy: params.energy,           // <-- add
+  energy: params.energy,           // <-- add this
   timestamp: params.timestamp ?? Date.now(),
 };
 ```
 
-**Fix (pi-mono side):** Export a helper that constructs `AssistantMessage` with
-all fields so downstream consumers don't have to track new additions manually.
-See **Task P1** below.
-
-### 2. Usage construction helpers ignore energy
-
-**Where:** `openclaw/src/agents/stream-message-shared.ts`
-
-`buildZeroUsage()` and `buildUsageWithNoCost()` construct `Usage` objects with
-hardcoded field lists. Energy fields on `UsageWithEnergy` are not represented.
-
-**Fix (openclaw side):** These functions produce `Usage` objects (not
-`UsageWithEnergy`), which is correct — energy lives on `AssistantMessage.energy`,
-not inside `Usage`. No change needed here as long as issue #1 is fixed.
-
-### 3. `normalizeUsage()` drops energy data in result pipeline
+#### 2. `normalizeUsage()` drops energy data in result pipeline
 
 **Where:** `openclaw/src/agents/usage.ts` and `pi-embedded-runner/run.ts`
 
 The usage normalization pipeline (`toNormalizedUsage`, `normalizeUsage`)
 extracts specific token fields by name and reconstructs a new object.
-Energy data from the original `AssistantMessage` is lost.
+Energy data from the original `AssistantMessage` is lost when building
+`EmbeddedPiAgentMeta`.
 
-**Fix (openclaw side):** When building `EmbeddedPiAgentMeta`, propagate
-`energy` from the last `AssistantMessage` alongside the normalized usage.
+**Fix:** When building `EmbeddedPiAgentMeta`, propagate `energy` from the
+last `AssistantMessage` alongside the normalized usage.
 
----
+### High Priority — needed for energy-aware mode
 
-## High-Priority Issues
-
-### 4. `createAgentSession` does not pass policy config
+#### 3. Wire policy config through openclaw's session creation
 
 **Where:** `openclaw/src/agents/pi-embedded-runner/run/attempt.ts`
 
-openclaw calls `createAgentSession()` with explicit named parameters. There is
-no pass-through for `policy`, `availableModels`, or `budget` — the new
-`AgentLoopConfig` fields added for energy-aware mode.
+openclaw calls `createAgentSession()` with explicit named parameters. Now that
+`createAgentSession` accepts `policy`, `availableModels`, `budget`, and
+`onCompact` (P2), openclaw needs to pass them.
 
-**Fix (openclaw side):** Add optional `policy`, `availableModels`, `budget`
-params to openclaw's session creation path, passed through to the agent loop.
+**Fix:** Add optional energy-aware config to openclaw's session creation path
+and forward to `createAgentSession()`.
 
-**Fix (pi-mono side):** Ensure `createAgentSession` in pi-coding-agent
-accepts and forwards these fields. See **Task P2** below.
+#### 4. Connect compaction signal to openclaw's compaction extension
 
-### 5. Model routing conflict
+**Where:** openclaw's context pruning / compaction extension
+
+The `onCompact` callback (P3) lets the agent loop notify the caller when the
+policy wants compaction. openclaw already has context pruning and compaction
+extensions but they're not connected to this signal.
+
+**Fix:** When constructing `createAgentSession` options, provide an `onCompact`
+callback that triggers openclaw's existing compaction mechanism.
+
+#### 5. Model routing coordination
 
 openclaw has its own model routing logic (provider-specific stream wrappers,
 gateway model selection). The `EnergyAwarePolicy` can also route to a different
@@ -97,43 +110,31 @@ model via `PolicyDecision.model`.
 - openclaw should populate `availableModels` with Neuralwatt models sorted by
   `cost.output` ascending, letting the policy pick from that pre-filtered set
 
-### 6. `shouldCompact` policy decision not wired
+No code fix needed — just pass the right `availableModels` when configuring
+the session.
 
-The `EnergyAwarePolicy` can set `shouldCompact: true` to request context
-compaction. The agent loop does **not** act on this flag — it's left to the
-caller. openclaw already has context pruning and compaction extensions, but
-they're not connected to the policy signal.
+### Medium Priority — nice to have
 
-**Fix (openclaw side):** When `shouldCompact` is set in a policy decision,
-trigger openclaw's existing compaction extension.
-
-**Fix (pi-mono side):** Add a `shouldCompact` callback to `AgentLoopConfig`
-so the agent loop can act on the signal directly. See **Task P3** below.
-
----
-
-## Medium-Priority Issues
-
-### 7. Plugin SDK does not re-export energy types
+#### 6. Plugin SDK does not re-export energy types
 
 **Where:** `openclaw/src/plugin-sdk/index.ts`
 
 openclaw's plugin SDK does not re-export any pi-ai or pi-agent-core types.
 Plugin authors who want to consume energy data must import directly from
-`@mariozechner/pi-ai`.
+`@mariozechner/pi-ai` or `@mariozechner/pi-coding-agent`.
 
-**Fix (openclaw side):** Re-export `EnergyUsage`, `EnergyBudget`,
-`RuntimePolicy`, `PolicyDecision` from the plugin SDK.
+**Fix:** Re-export `EnergyUsage`, `EnergyBudget`, `RuntimePolicy`,
+`PolicyDecision` from the plugin SDK.
 
-### 8. Telemetry pipeline not wired
+#### 7. Telemetry pipeline not wired
 
 pi-mono's `TelemetryRecord` and JSONL serialization (`energy-types.ts`) have
 no consumer in openclaw. Telemetry records need a destination.
 
-**Fix (openclaw side):** Use `SessionManager.appendCustomEntry()` to persist
-telemetry records per session, or write to a separate JSONL file.
+**Fix:** Use `SessionManager.appendCustomEntry()` to persist telemetry records
+per session, or write to a separate JSONL file.
 
-### 9. Tool execute signature variance
+#### 8. Tool execute signature variance
 
 openclaw uses two `execute` signatures for tools:
 - `(toolCallId, params, signal?, onUpdate?)`
@@ -148,63 +149,16 @@ Only matters if adopting `TaskAgent` directly.
 
 ---
 
-## Preparatory Tasks (pi-mono side)
-
-These are code changes in energy-aware-pi-mono that reduce friction for
-openclaw integration.
-
-### P1: Add `buildAssistantMessage` helper to pi-ai
-
-Export a factory function that constructs `AssistantMessage` with all current
-fields (including `energy`). This gives downstream consumers a single
-construction point that stays up to date as the type evolves.
-
-**Status:** Done (branch `openclaw/integration`)
-
-### P2: Forward policy config through `createAgentSession`
-
-Ensure `createAgentSession` in pi-coding-agent accepts `policy`,
-`availableModels`, and `budget` and passes them to the agent loop config.
-
-**Status:** TODO (requires pi-coding-agent changes)
-
-### P3: Add `onCompact` callback to `AgentLoopConfig`
-
-When the policy sets `shouldCompact: true`, invoke a caller-provided callback
-instead of silently ignoring the signal. This lets openclaw wire it to its
-existing compaction extension.
-
-**Status:** Done (branch `openclaw/integration`)
-
-### P4: Export energy types from package entry points
-
-Verify that `EnergyUsage`, `EnergyBudget`, `RuntimePolicy`, `PolicyDecision`,
-`UsageWithEnergy`, `TelemetryRecord` are all exported from their respective
-package entry points (`packages/ai/src/index.ts`,
-`packages/agent/src/index.ts`).
-
-**Status:** Already exported (verified)
-
-### P5: Add `energy` passthrough guidance to CHANGELOG
-
-Document in both `packages/ai/CHANGELOG.md` and `packages/agent/CHANGELOG.md`
-that downstream consumers constructing `AssistantMessage` manually must add
-the optional `energy` field to avoid silent data loss.
-
-**Status:** Done (branch `openclaw/integration`)
-
----
-
 ## Integration Sequence
 
 Recommended order of operations:
 
-1. **Land pi-mono changes** (P1, P3, P5) — this branch
-2. **Bump openclaw's pi-mono deps** to the new version
-3. **Fix `buildAssistantMessage()`** in openclaw (issue #1) — smallest change,
+1. **Bump openclaw's pi-mono deps** to the energy-aware fork
+2. **Fix `buildAssistantMessage()`** in openclaw (issue #1) — smallest change,
    biggest impact
-4. **Wire policy config** through openclaw's session creation (issue #4)
-5. **Connect compaction signal** (issue #6)
-6. **Add telemetry persistence** (issue #8)
-7. **Re-export types** from plugin SDK (issue #7)
+3. **Fix `normalizeUsage()`** energy propagation (issue #2)
+4. **Wire policy config** through openclaw's session creation (issue #3)
+5. **Connect compaction signal** (issue #4)
+6. **Add telemetry persistence** (issue #7)
+7. **Re-export types** from plugin SDK (issue #6)
 8. **Test end-to-end** with Neuralwatt models and energy budgets

--- a/OPENCLAW_INTEGRATION.md
+++ b/OPENCLAW_INTEGRATION.md
@@ -1,0 +1,210 @@
+# OpenClaw Integration: Energy Awareness
+
+This document tracks the work needed to bring energy awareness features from
+`energy-aware-pi-mono` into the [openclaw](~/dev/openclaw) project.
+
+## Background
+
+openclaw depends on 4 pi-mono packages (`@mariozechner/pi-ai`,
+`@mariozechner/pi-agent-core`, `@mariozechner/pi-coding-agent`,
+`@mariozechner/pi-tui`), all at v0.57.1 (published as `@neuralwatt/*`).
+
+All energy-aware changes are additive and opt-in — no existing APIs were broken.
+However, openclaw's internal patterns create friction that must be addressed on
+**both** sides.
+
+---
+
+## Critical Issues (must fix before integration)
+
+### 1. `buildAssistantMessage()` drops the `energy` field
+
+**Where:** `openclaw/src/agents/stream-message-shared.ts`
+
+openclaw's `buildAssistantMessage()` constructs a new `AssistantMessage` with
+explicit fields and does **not** pass through unknown properties. The `energy?:
+EnergyUsage` field added to `AssistantMessage` in pi-ai is silently discarded.
+
+**Fix (openclaw side):** Add `energy` to `buildAssistantMessage()`:
+```typescript
+return {
+  role: "assistant",
+  content: params.content,
+  stopReason: params.stopReason,
+  api: params.model.api,
+  provider: params.model.provider,
+  model: params.model.id,
+  usage: params.usage,
+  energy: params.energy,           // <-- add
+  timestamp: params.timestamp ?? Date.now(),
+};
+```
+
+**Fix (pi-mono side):** Export a helper that constructs `AssistantMessage` with
+all fields so downstream consumers don't have to track new additions manually.
+See **Task P1** below.
+
+### 2. Usage construction helpers ignore energy
+
+**Where:** `openclaw/src/agents/stream-message-shared.ts`
+
+`buildZeroUsage()` and `buildUsageWithNoCost()` construct `Usage` objects with
+hardcoded field lists. Energy fields on `UsageWithEnergy` are not represented.
+
+**Fix (openclaw side):** These functions produce `Usage` objects (not
+`UsageWithEnergy`), which is correct — energy lives on `AssistantMessage.energy`,
+not inside `Usage`. No change needed here as long as issue #1 is fixed.
+
+### 3. `normalizeUsage()` drops energy data in result pipeline
+
+**Where:** `openclaw/src/agents/usage.ts` and `pi-embedded-runner/run.ts`
+
+The usage normalization pipeline (`toNormalizedUsage`, `normalizeUsage`)
+extracts specific token fields by name and reconstructs a new object.
+Energy data from the original `AssistantMessage` is lost.
+
+**Fix (openclaw side):** When building `EmbeddedPiAgentMeta`, propagate
+`energy` from the last `AssistantMessage` alongside the normalized usage.
+
+---
+
+## High-Priority Issues
+
+### 4. `createAgentSession` does not pass policy config
+
+**Where:** `openclaw/src/agents/pi-embedded-runner/run/attempt.ts`
+
+openclaw calls `createAgentSession()` with explicit named parameters. There is
+no pass-through for `policy`, `availableModels`, or `budget` — the new
+`AgentLoopConfig` fields added for energy-aware mode.
+
+**Fix (openclaw side):** Add optional `policy`, `availableModels`, `budget`
+params to openclaw's session creation path, passed through to the agent loop.
+
+**Fix (pi-mono side):** Ensure `createAgentSession` in pi-coding-agent
+accepts and forwards these fields. See **Task P2** below.
+
+### 5. Model routing conflict
+
+openclaw has its own model routing logic (provider-specific stream wrappers,
+gateway model selection). The `EnergyAwarePolicy` can also route to a different
+model via `PolicyDecision.model`.
+
+**Resolution:** These are complementary, not conflicting:
+- openclaw's routing selects the **initial** model and provider config
+- The policy's routing selects a **cheaper alternative** from `availableModels`
+  under budget pressure
+- openclaw should populate `availableModels` with Neuralwatt models sorted by
+  `cost.output` ascending, letting the policy pick from that pre-filtered set
+
+### 6. `shouldCompact` policy decision not wired
+
+The `EnergyAwarePolicy` can set `shouldCompact: true` to request context
+compaction. The agent loop does **not** act on this flag — it's left to the
+caller. openclaw already has context pruning and compaction extensions, but
+they're not connected to the policy signal.
+
+**Fix (openclaw side):** When `shouldCompact` is set in a policy decision,
+trigger openclaw's existing compaction extension.
+
+**Fix (pi-mono side):** Add a `shouldCompact` callback to `AgentLoopConfig`
+so the agent loop can act on the signal directly. See **Task P3** below.
+
+---
+
+## Medium-Priority Issues
+
+### 7. Plugin SDK does not re-export energy types
+
+**Where:** `openclaw/src/plugin-sdk/index.ts`
+
+openclaw's plugin SDK does not re-export any pi-ai or pi-agent-core types.
+Plugin authors who want to consume energy data must import directly from
+`@mariozechner/pi-ai`.
+
+**Fix (openclaw side):** Re-export `EnergyUsage`, `EnergyBudget`,
+`RuntimePolicy`, `PolicyDecision` from the plugin SDK.
+
+### 8. Telemetry pipeline not wired
+
+pi-mono's `TelemetryRecord` and JSONL serialization (`energy-types.ts`) have
+no consumer in openclaw. Telemetry records need a destination.
+
+**Fix (openclaw side):** Use `SessionManager.appendCustomEntry()` to persist
+telemetry records per session, or write to a separate JSONL file.
+
+### 9. Tool execute signature variance
+
+openclaw uses two `execute` signatures for tools:
+- `(toolCallId, params, signal?, onUpdate?)`
+- `(toolCallId, params, onUpdate?, ctx?, signal?)`
+
+The agent loop in pi-mono uses the first signature. The `TaskAgent`
+orchestrator (if openclaw ever uses it) would need tools matching that
+signature.
+
+**Fix:** Not blocking — openclaw's tools work with the agent loop today.
+Only matters if adopting `TaskAgent` directly.
+
+---
+
+## Preparatory Tasks (pi-mono side)
+
+These are code changes in energy-aware-pi-mono that reduce friction for
+openclaw integration.
+
+### P1: Add `buildAssistantMessage` helper to pi-ai
+
+Export a factory function that constructs `AssistantMessage` with all current
+fields (including `energy`). This gives downstream consumers a single
+construction point that stays up to date as the type evolves.
+
+**Status:** Done (branch `openclaw/integration`)
+
+### P2: Forward policy config through `createAgentSession`
+
+Ensure `createAgentSession` in pi-coding-agent accepts `policy`,
+`availableModels`, and `budget` and passes them to the agent loop config.
+
+**Status:** TODO (requires pi-coding-agent changes)
+
+### P3: Add `onCompact` callback to `AgentLoopConfig`
+
+When the policy sets `shouldCompact: true`, invoke a caller-provided callback
+instead of silently ignoring the signal. This lets openclaw wire it to its
+existing compaction extension.
+
+**Status:** Done (branch `openclaw/integration`)
+
+### P4: Export energy types from package entry points
+
+Verify that `EnergyUsage`, `EnergyBudget`, `RuntimePolicy`, `PolicyDecision`,
+`UsageWithEnergy`, `TelemetryRecord` are all exported from their respective
+package entry points (`packages/ai/src/index.ts`,
+`packages/agent/src/index.ts`).
+
+**Status:** Already exported (verified)
+
+### P5: Add `energy` passthrough guidance to CHANGELOG
+
+Document in both `packages/ai/CHANGELOG.md` and `packages/agent/CHANGELOG.md`
+that downstream consumers constructing `AssistantMessage` manually must add
+the optional `energy` field to avoid silent data loss.
+
+**Status:** Done (branch `openclaw/integration`)
+
+---
+
+## Integration Sequence
+
+Recommended order of operations:
+
+1. **Land pi-mono changes** (P1, P3, P5) — this branch
+2. **Bump openclaw's pi-mono deps** to the new version
+3. **Fix `buildAssistantMessage()`** in openclaw (issue #1) — smallest change,
+   biggest impact
+4. **Wire policy config** through openclaw's session creation (issue #4)
+5. **Connect compaction signal** (issue #6)
+6. **Add telemetry persistence** (issue #8)
+7. **Re-export types** from plugin SDK (issue #7)
+8. **Test end-to-end** with Neuralwatt models and energy budgets

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ npm run demo:hn -w packages/benchmarks
 
 Both demos require `NEURALWATT_API_KEY` to be set. They are designed to inspire thinking and to show what is possible with energy awareness.
 
+Pass flags after a `--` separator (required by npm to forward args to the script):
+```bash
+npm run demo:coding -w packages/benchmarks -- --runs 4 --hard
+npm run demo:coding -w packages/benchmarks -- --clear-memory
+npm run demo:hn -w packages/benchmarks -- --duration 60 --fast
+```
+
 # Energy Observability
 The energy data coming back from the supported APIs is useful for billing, dashboards and compliance.  Paired with location information (available from 
 info@neuralwatt.com on request) it can also be used for Scope 3 carbon accounting.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Energy-Aware Pi Monorepo
-This is a hard fork of the [Pi monorepo](https://github.com/badlogic/pi-mono) where we are baking in the concept of energy-awareness to agents.  What's energy-awareness? 
-Well its essentially making decisions based on the energy & power constriants in your envioronment.  For example we have extending the 
-Pi coding agent to make semantic model routing decisions based on the expected energy/performance tradeoff of that action.  There are many 
+This is a hard fork of the [Pi monorepo](https://github.com/badlogic/pi-mono) where we are extending the agent framework to support energy-awareness.  What's energy-awareness? 
+It's essentially making decisions based on the energy & power constraints in your environment.  For example we have extended the
+Pi coding agent to make model routing decisions based on the expected energy/performance tradeoff of that action.  There are many 
 other examples we've outlined here: [ENERGY_AWARENESS.md](ENERGY_AWARENESS.md).
 
 The actual per-request energy values come from the Neuralwatt AI model platform here: https://portal.neuralwatt.com/
@@ -14,6 +14,55 @@ And this is the demo HN watcher agent looks like in action:
 
 You can run these from the packages/benchmarks directory and currently they are designed to inspire thinking and to show what is possible
 with energy awareness.  We may think about integrating these capabilities to other tools at some point.
+
+# Energy Observability
+The energy data coming back from the supported APIs is useful for billing, dashboards and compliance.  Paired with location information (available from 
+info@neuralwatt.com on request) it can also be used for Scope 3 carbon accounting.
+
+# Energy-aware Policy Framework
+We implement a RuntimePolicy interface that anyone can implement to help make intelligent agent decisions.  We provide an energy-aware policy which 
+implements a set of heuristics to make optimal tradeoffs on how models are called and which models are used for various sub-tasks in the agent to maintain
+problem convergence while dramatically reducing the energy required for those tasks.  On task failure we aggressively upgrade the capabilities to larger and
+more capable models as wasting time on requests which aren't converging isn't productive from an energy use point of view.  In the initial demos we've created
+we've found that solution convergence takes roughly the same amount of sub-tasks while using dramatically less energy (in many cases <80%). 
+
+These capabilities are being integrated into OpenClaw — see [OPENCLAW_INTEGRATION.md](OPENCLAW_INTEGRATION.md)
+
+## What Changed from Upstream
+
+| Package | Changes |
+|---------|---------|
+| `packages/ai` | `EnergyUsage` type on `AssistantMessage`, energy extraction from OpenAI-compatible responses, `TelemetryRecord` JSONL schema, `buildAssistantMessage()` helper, Neuralwatt provider + models |
+| `packages/agent` | `RuntimePolicy` interface, `BaselinePolicy`, `EnergyAwarePolicy` (5-strategy chain), policy hooks in agent loop (`beforeModelCall`/`afterModelCall`), `onCompact` callback, `policy`/`budget`/`availableModels` on `Agent` and `AgentLoopConfig` |
+| `packages/coding-agent` | `createAgentSession` accepts policy config, re-exports energy types |
+| `packages/benchmarks` | New package — benchmark runner, task definitions, comparison reports, live demos |
+
+All changes are additive and opt-in. When no policy is configured, behavior is identical to upstream pi-mono.
+
+## Quickstart
+
+```bash
+export NEURALWATT_API_KEY="your-key-here"
+```
+
+```typescript
+import { createAgentSession } from "@mariozechner/pi-coding-agent";
+import { EnergyAwarePolicy } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+
+const { session } = await createAgentSession({
+   model: getModel("neuralwatt", "mistralai/Devstral-Small-2-24B-Instruct-2512"),
+   policy: new EnergyAwarePolicy(),
+   budget: { energy_budget_joules: 50 },
+   availableModels: [
+      getModel("neuralwatt", "Qwen/Qwen3.5-35B-A3B"),
+      getModel("neuralwatt", "mistralai/Devstral-Small-2-24B-Instruct-2512"),
+      getModel("neuralwatt", "Qwen/Qwen3.5-397B-A17B-FP8"),
+   ],
+});
+```
+
+See [ENERGY_AWARENESS.md](ENERGY_AWARENESS.md) for the full implementation reference.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,18 @@ other examples we've outlined here: [ENERGY_AWARENESS.md](ENERGY_AWARENESS.md).
 The actual per-request energy values come from the Neuralwatt AI model platform here: https://portal.neuralwatt.com/
 
 This is what the demo energy-aware coding agent looks like in action:
+```bash
+npm run demo:coding -w packages/benchmarks
+```
 <img width="1717" height="1492" alt="EADemo" src="https://github.com/user-attachments/assets/da7b32ae-7eaa-4146-b5f6-96905d4adb4f" />
 
 And this is the demo HN watcher agent looks like in action:
+```bash
+npm run demo:hn -w packages/benchmarks
+```
 <img width="712" height="812" alt="HN" src="https://github.com/user-attachments/assets/7767e808-7931-44a8-aa4a-b2219bdf919d" />
 
-You can run these from the packages/benchmarks directory and currently they are designed to inspire thinking and to show what is possible
-with energy awareness.  We may think about integrating these capabilities to other tools at some point.
+Both demos require `NEURALWATT_API_KEY` to be set. They are designed to inspire thinking and to show what is possible with energy awareness.
 
 # Energy Observability
 The energy data coming back from the supported APIs is useful for billing, dashboards and compliance.  Paired with location information (available from 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -11,10 +11,18 @@
 - Added `BaselinePolicy` — no-op policy for benchmarking that logs telemetry without intervention
 - Added `EnergyAwarePolicy` — budget-aware policy with 5-strategy chain: reasoning reduction, token limit reduction, model routing, context compaction, and budget exhaustion abort
 - Added `availableModels` and `budget` fields to `AgentLoopConfig` for policy-driven model routing and budget enforcement
+- Added `onCompact` callback to `AgentLoopConfig` — invoked when the policy sets `shouldCompact: true`, allowing callers (e.g. openclaw) to wire in their own context compaction logic
+- Added `policy`, `availableModels`, `budget`, and `onCompact` to `AgentOptions` and the `Agent` class, so callers using the high-level `Agent` API can configure energy-aware mode without dropping to the low-level `agentLoop()` function
+- Added runtime accessors on `Agent`: `policy`, `availableModels`, `budget` (get/set) for mid-session configuration changes
 
 ### Fixed
 
 - Fixed `AgentLoopConfig` fields `availableModels` and `budget` not being passed through to `PolicyContext` in the agent loop — previously both were hardcoded as empty, preventing `EnergyAwarePolicy` from triggering model routing or budget pressure in real runs
+
+### Integration Notes (openclaw)
+
+- **Downstream consumers constructing `AssistantMessage` manually must include the optional `energy` field** to avoid silent data loss. Use `buildAssistantMessage()` from `@mariozechner/pi-ai` instead of object literals.
+- The `onCompact` callback replaces the previous silent ignore of `shouldCompact` — callers should wire this to their existing compaction mechanism.
 
 ## [0.57.1] - 2026-03-07
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -202,6 +202,11 @@ async function runLoop(
 				}
 			}
 
+			// Handle compaction if policy requested it
+			if (policyDecision?.shouldCompact && config.onCompact) {
+				currentContext.messages = await config.onCompact(currentContext.messages);
+			}
+
 			// Stream assistant response
 			const message = await streamAssistantResponse(
 				currentContext,

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -204,7 +204,40 @@ async function runLoop(
 
 			// Handle compaction if policy requested it
 			if (policyDecision?.shouldCompact && config.onCompact) {
-				currentContext.messages = await config.onCompact(currentContext.messages);
+				try {
+					currentContext.messages = await config.onCompact(currentContext.messages);
+				} catch (err) {
+					const compactErrorMessage: AssistantMessage = {
+						role: "assistant",
+						content: [
+							{
+								type: "text",
+								text: "Compaction failed: " + (err instanceof Error ? err.message : String(err)),
+							},
+						],
+						api: config.model.api,
+						provider: config.model.provider,
+						model: config.model.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error",
+						timestamp: Date.now(),
+					};
+					currentContext.messages.push(compactErrorMessage);
+					newMessages.push(compactErrorMessage);
+					stream.push({ type: "message_start", message: compactErrorMessage });
+					stream.push({ type: "message_end", message: compactErrorMessage });
+					stream.push({ type: "turn_end", message: compactErrorMessage, toolResults: [] });
+					stream.push({ type: "agent_end", messages: newMessages });
+					stream.end(newMessages);
+					return;
+				}
 			}
 
 			// Stream assistant response

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -15,6 +15,7 @@ import {
 	type Transport,
 } from "@mariozechner/pi-ai";
 import { agentLoop, agentLoopContinue } from "./agent-loop.js";
+import type { EnergyBudget, RuntimePolicy } from "./policy/types.js";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -97,6 +98,24 @@ export interface AgentOptions {
 	 * Default: 60000 (60 seconds). Set to 0 to disable the cap.
 	 */
 	maxRetryDelayMs?: number;
+
+	/**
+	 * Optional runtime policy for energy-aware budgeting.
+	 * When set, the agent loop calls `beforeModelCall`/`afterModelCall` on each turn.
+	 */
+	policy?: RuntimePolicy;
+
+	/** Models available for policy-driven model routing, sorted by cost.output ascending. */
+	availableModels?: Model<any>[];
+
+	/** Energy/time budget for policy-driven budget enforcement. */
+	budget?: EnergyBudget;
+
+	/**
+	 * Called when the policy requests context compaction.
+	 * If not provided, the `shouldCompact` signal is ignored.
+	 */
+	onCompact?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
 }
 
 export class Agent {
@@ -129,6 +148,10 @@ export class Agent {
 	private _thinkingBudgets?: ThinkingBudgets;
 	private _transport: Transport;
 	private _maxRetryDelayMs?: number;
+	private _policy?: RuntimePolicy;
+	private _availableModels?: Model<any>[];
+	private _budget?: EnergyBudget;
+	private _onCompact?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
 
 	constructor(opts: AgentOptions = {}) {
 		this._state = { ...this._state, ...opts.initialState };
@@ -143,6 +166,10 @@ export class Agent {
 		this._thinkingBudgets = opts.thinkingBudgets;
 		this._transport = opts.transport ?? "sse";
 		this._maxRetryDelayMs = opts.maxRetryDelayMs;
+		this._policy = opts.policy;
+		this._availableModels = opts.availableModels;
+		this._budget = opts.budget;
+		this._onCompact = opts.onCompact;
 	}
 
 	/**
@@ -201,6 +228,36 @@ export class Agent {
 	 */
 	set maxRetryDelayMs(value: number | undefined) {
 		this._maxRetryDelayMs = value;
+	}
+
+	/** Get the current runtime policy. */
+	get policy(): RuntimePolicy | undefined {
+		return this._policy;
+	}
+
+	/** Set or clear the runtime policy for energy-aware budgeting. */
+	set policy(value: RuntimePolicy | undefined) {
+		this._policy = value;
+	}
+
+	/** Get the available models for policy-driven routing. */
+	get availableModels(): Model<any>[] | undefined {
+		return this._availableModels;
+	}
+
+	/** Set available models for policy-driven routing (sorted by cost.output ascending). */
+	set availableModels(value: Model<any>[] | undefined) {
+		this._availableModels = value;
+	}
+
+	/** Get the current energy/time budget. */
+	get budget(): EnergyBudget | undefined {
+		return this._budget;
+	}
+
+	/** Set or clear the energy/time budget. */
+	set budget(value: EnergyBudget | undefined) {
+		this._budget = value;
 	}
 
 	get state(): AgentState {
@@ -452,6 +509,10 @@ export class Agent {
 				return this.dequeueSteeringMessages();
 			},
 			getFollowUpMessages: async () => this.dequeueFollowUpMessages(),
+			policy: this._policy,
+			availableModels: this._availableModels,
+			budget: this._budget,
+			onCompact: this._onCompact,
 		};
 
 		let partial: AgentMessage | null = null;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -108,6 +108,14 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 
 	/** Energy/time budget for policy-driven budget enforcement. */
 	budget?: EnergyBudget;
+
+	/**
+	 * Called when the policy sets `shouldCompact: true`.
+	 * The caller is responsible for performing context compaction (e.g. summarizing
+	 * older messages) and returning the compacted message list.
+	 * If not provided, the `shouldCompact` signal is ignored.
+	 */
+	onCompact?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
 }
 
 /**

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Added `energy?: EnergyUsage` field to `AssistantMessage` for per-request energy telemetry.
 - Added automatic energy metric parsing from OpenAI-compatible streaming responses (Neuralwatt and any provider including energy fields in usage).
 - Added `TelemetryRecord` interface and JSONL serialization/parsing utilities in `energy-types.ts` for structured telemetry logging.
+- Added `buildAssistantMessage()` factory function — constructs `AssistantMessage` with all current fields including `energy`. Downstream consumers should use this instead of object literals to stay forward-compatible as the type evolves.
+
+### Integration Notes (openclaw)
+
+- **Downstream consumers constructing `AssistantMessage` manually must include the optional `energy` field** to avoid silent data loss. openclaw's `buildAssistantMessage()` in `stream-message-shared.ts` is affected — it explicitly constructs objects with fixed fields and drops `energy`.
 
 ### Fixed
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -346,9 +346,10 @@ interface EnergyRef {
  * Returns the parsed EnergyUsage or undefined if the line isn't an energy comment.
  */
 function parseEnergyComment(line: string): EnergyUsage | undefined {
-	if (!line.startsWith(": energy ")) return undefined;
+	const trimmed = line.trimEnd();
+	if (!trimmed.startsWith(": energy ")) return undefined;
 	try {
-		const data = JSON.parse(line.slice(9)) as Record<string, unknown>;
+		const data = JSON.parse(trimmed.slice(9)) as Record<string, unknown>;
 		const ej = typeof data.energy_joules === "number" ? data.energy_joules : undefined;
 		const ek = typeof data.energy_kwh === "number" ? data.energy_kwh : undefined;
 		const ds = typeof data.duration_seconds === "number" ? data.duration_seconds : undefined;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -127,10 +127,25 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			};
 
 			for await (const chunk of openaiStream) {
+				// Inspect the raw chunk for energy fields that may be outside chunk.usage
+				const chunkAny = chunk as unknown as Record<string, unknown>;
+				if (chunkAny.energy_joules != null || chunkAny.energy_kwh != null) {
+					const ej = typeof chunkAny.energy_joules === "number" ? chunkAny.energy_joules : undefined;
+					const ek = typeof chunkAny.energy_kwh === "number" ? chunkAny.energy_kwh : undefined;
+					const ds = typeof chunkAny.duration_seconds === "number" ? chunkAny.duration_seconds : undefined;
+					if (ej !== undefined || ek !== undefined) {
+						output.energy = {
+							energy_joules: ej ?? (ek !== undefined ? ek * 3_600_000 : 0),
+							energy_kwh: ek ?? (ej !== undefined ? ej / 3_600_000 : 0),
+							duration_seconds: ds ?? 0,
+						};
+					}
+				}
+
 				if (chunk.usage) {
 					output.usage = parseChunkUsage(chunk.usage, model);
 
-					// Parse energy telemetry from Neuralwatt (or other providers that include it)
+					// Parse energy telemetry from usage object (Neuralwatt or compatible providers)
 					const usageAny = chunk.usage as unknown as Record<string, unknown>;
 					const energyJoules = typeof usageAny.energy_joules === "number" ? usageAny.energy_joules : undefined;
 					const energyKwh = typeof usageAny.energy_kwh === "number" ? usageAny.energy_kwh : undefined;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -13,6 +13,7 @@ import { calculateCost, supportsXhigh } from "../models.js";
 import type {
 	AssistantMessage,
 	Context,
+	EnergyUsage,
 	Message,
 	Model,
 	OpenAICompletionsCompat,
@@ -85,7 +86,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 
 		try {
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const client = createClient(model, context, apiKey, options?.headers);
+			const energyRef: EnergyRef = {};
+			const client = createClient(model, context, apiKey, options?.headers, energyRef);
 			let params = buildParams(model, context, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -127,21 +129,6 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			};
 
 			for await (const chunk of openaiStream) {
-				// Inspect the raw chunk for energy fields that may be outside chunk.usage
-				const chunkAny = chunk as unknown as Record<string, unknown>;
-				if (chunkAny.energy_joules != null || chunkAny.energy_kwh != null) {
-					const ej = typeof chunkAny.energy_joules === "number" ? chunkAny.energy_joules : undefined;
-					const ek = typeof chunkAny.energy_kwh === "number" ? chunkAny.energy_kwh : undefined;
-					const ds = typeof chunkAny.duration_seconds === "number" ? chunkAny.duration_seconds : undefined;
-					if (ej !== undefined || ek !== undefined) {
-						output.energy = {
-							energy_joules: ej ?? (ek !== undefined ? ek * 3_600_000 : 0),
-							energy_kwh: ek ?? (ej !== undefined ? ej / 3_600_000 : 0),
-							duration_seconds: ds ?? 0,
-						};
-					}
-				}
-
 				if (chunk.usage) {
 					output.usage = parseChunkUsage(chunk.usage, model);
 
@@ -303,6 +290,11 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				throw new Error("An unknown error occurred");
 			}
 
+			// Apply energy captured from SSE comment lines (e.g. Neuralwatt `: energy {...}`)
+			if (!output.energy && energyRef.energy) {
+				output.energy = energyRef.energy;
+			}
+
 			stream.push({ type: "done", reason: output.stopReason, message: output });
 			stream.end();
 		} catch (error) {
@@ -341,11 +333,93 @@ export const streamSimpleOpenAICompletions: StreamFunction<"openai-completions",
 	} satisfies OpenAICompletionsOptions);
 };
 
+/**
+ * Shared mutable ref for energy data extracted from SSE comment lines.
+ * The custom fetch wrapper writes to this; the streaming loop reads it after the stream ends.
+ */
+interface EnergyRef {
+	energy?: EnergyUsage;
+}
+
+/**
+ * Parse an SSE comment line like `: energy {"energy_joules": 26.96, ...}`.
+ * Returns the parsed EnergyUsage or undefined if the line isn't an energy comment.
+ */
+function parseEnergyComment(line: string): EnergyUsage | undefined {
+	if (!line.startsWith(": energy ")) return undefined;
+	try {
+		const data = JSON.parse(line.slice(9)) as Record<string, unknown>;
+		const ej = typeof data.energy_joules === "number" ? data.energy_joules : undefined;
+		const ek = typeof data.energy_kwh === "number" ? data.energy_kwh : undefined;
+		const ds = typeof data.duration_seconds === "number" ? data.duration_seconds : undefined;
+		if (ej === undefined && ek === undefined) return undefined;
+		return {
+			energy_joules: ej ?? (ek !== undefined ? ek * 3_600_000 : 0),
+			energy_kwh: ek ?? (ej !== undefined ? ej / 3_600_000 : 0),
+			duration_seconds: ds ?? 0,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Create a custom fetch function that intercepts SSE comment lines containing
+ * energy telemetry (e.g. from Neuralwatt). The OpenAI SDK's SSE decoder
+ * silently drops comment lines (lines starting with `:`), so we need to
+ * extract energy data before the SDK sees the response.
+ */
+function createEnergyCapturingFetch(energyRef: EnergyRef): typeof globalThis.fetch {
+	return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+		const response = await globalThis.fetch(input, init);
+		const body = response.body;
+		if (!body) return response;
+
+		let buffer = "";
+		const decoder = new TextDecoder();
+		const transform = new TransformStream<Uint8Array, Uint8Array>({
+			transform(chunk, controller) {
+				// Pass the chunk through unmodified — the SDK still sees all data
+				controller.enqueue(chunk);
+
+				// Also scan for energy comment lines
+				buffer += decoder.decode(chunk, { stream: true });
+				const lines = buffer.split("\n");
+				// Keep the last incomplete line in the buffer
+				buffer = lines.pop() ?? "";
+				for (const line of lines) {
+					const energy = parseEnergyComment(line);
+					if (energy) {
+						energyRef.energy = energy;
+					}
+				}
+			},
+			flush() {
+				// Process any remaining buffer
+				if (buffer) {
+					const energy = parseEnergyComment(buffer);
+					if (energy) {
+						energyRef.energy = energy;
+					}
+				}
+			},
+		});
+
+		const newBody = body.pipeThrough(transform);
+		return new Response(newBody, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	};
+}
+
 function createClient(
 	model: Model<"openai-completions">,
 	context: Context,
 	apiKey?: string,
 	optionsHeaders?: Record<string, string>,
+	energyRef?: EnergyRef,
 ) {
 	if (!apiKey) {
 		if (!process.env.OPENAI_API_KEY) {
@@ -376,6 +450,8 @@ function createClient(
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: headers,
+		// When an energyRef is provided, wrap fetch to capture SSE energy comments
+		...(energyRef ? { fetch: createEnergyCapturingFetch(energyRef) } : {}),
 	});
 }
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -180,8 +180,9 @@ export function convertResponsesMessages<TApi extends Api>(
 						content: [{ type: "output_text", text: sanitizeSurrogates(textBlock.text), annotations: [] }],
 						status: "completed",
 						id: msgId,
-						phase: parsedSignature?.phase,
-					} satisfies ResponseOutputMessage);
+						// phase is a newer API field not yet in the openai SDK types
+						...(parsedSignature?.phase ? { phase: parsedSignature.phase } : {}),
+					} as ResponseOutputMessage);
 				} else if (block.type === "toolCall") {
 					const toolCall = block as ToolCall;
 					const [callId, itemIdRaw] = toolCall.id.split("|");
@@ -419,7 +420,7 @@ export async function processResponsesStream<TApi extends Api>(
 				currentBlock = null;
 			} else if (item.type === "message" && currentBlock?.type === "text") {
 				currentBlock.text = item.content.map((c) => (c.type === "output_text" ? c.text : c.refusal)).join("");
-				currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
+				currentBlock.textSignature = encodeTextSignatureV1(item.id, (item as any).phase ?? undefined);
 				stream.push({
 					type: "text_end",
 					contentIndex: blockIndex(),

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -212,6 +212,38 @@ export interface ToolResultMessage<TDetails = any> {
 
 export type Message = UserMessage | AssistantMessage | ToolResultMessage;
 
+/**
+ * Build an AssistantMessage with all current fields.
+ *
+ * Downstream consumers that construct AssistantMessage manually risk silently
+ * dropping new optional fields (e.g. `energy`). Use this helper to stay
+ * forward-compatible as the type evolves.
+ */
+export function buildAssistantMessage(params: {
+	content: AssistantMessage["content"];
+	api: Api;
+	provider: Provider;
+	model: string;
+	usage: Usage;
+	stopReason: StopReason;
+	energy?: EnergyUsage;
+	errorMessage?: string;
+	timestamp?: number;
+}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: params.content,
+		api: params.api,
+		provider: params.provider,
+		model: params.model,
+		usage: params.usage,
+		energy: params.energy,
+		stopReason: params.stopReason,
+		errorMessage: params.errorMessage,
+		timestamp: params.timestamp ?? Date.now(),
+	};
+}
+
 import type { TSchema } from "@sinclair/typebox";
 
 export interface Tool<TParameters extends TSchema = TSchema> {

--- a/packages/benchmarks/src/demos/coding-agent.ts
+++ b/packages/benchmarks/src/demos/coding-agent.ts
@@ -1538,14 +1538,15 @@ async function main(): Promise<void> {
 		allowPositionals: true,
 	});
 
+	if (values["clear-memory"]) {
+		clearMemory();
+		console.log("Memory cleared (~/.energy-demo-memory.json deleted).");
+		process.exit(0);
+	}
+
 	if (!process.env.NEURALWATT_API_KEY) {
 		console.error("NEURALWATT_API_KEY required");
 		process.exit(1);
-	}
-
-	if (values["clear-memory"]) {
-		clearMemory();
-		console.log("Memory cleared.");
 	}
 
 	registerBuiltInApiProviders();

--- a/packages/benchmarks/src/demos/coding-agent.ts
+++ b/packages/benchmarks/src/demos/coding-agent.ts
@@ -753,16 +753,30 @@ async function runCodingAgent(
 
 		messages.push({ role: "user", content: prompt, timestamp: Date.now() });
 
-		const assistantMsg = await completeSimple(
-			effectiveModel,
-			{ systemPrompt: SYSTEM_PROMPT, messages },
-			{ apiKey, ...(turnMaxTokens ? { maxTokens: turnMaxTokens } : {}) },
-		);
-
-		// Detect API errors (completeSimple doesn't throw — returns stopReason: "error")
-		const errorMsg = (assistantMsg as unknown as Record<string, unknown>).errorMessage;
-		if (assistantMsg.stopReason === "error" || errorMsg) {
-			throw new Error(`API error (${effectiveModel.id}): ${errorMsg ?? "unknown"}`);
+		let assistantMsg: AssistantMessage | undefined;
+		let lastError: string | undefined;
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const msg = await completeSimple(
+				effectiveModel,
+				{ systemPrompt: SYSTEM_PROMPT, messages },
+				{ apiKey, ...(turnMaxTokens ? { maxTokens: turnMaxTokens } : {}) },
+			);
+			const errorMsg = (msg as unknown as Record<string, unknown>).errorMessage;
+			if (msg.stopReason === "error" || errorMsg) {
+				lastError = `${errorMsg ?? "unknown"}`;
+				if (attempt < 2) {
+					console.log(
+						`  \x1b[33m⚠ API error (${effectiveModel.id}): ${lastError} — retrying (${attempt + 1}/3)…\x1b[0m`,
+					);
+					await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+				}
+			} else {
+				assistantMsg = msg;
+				break;
+			}
+		}
+		if (!assistantMsg) {
+			throw new Error(`API error (${effectiveModel.id}): ${lastError} (after 3 attempts)`);
 		}
 
 		messages.push(assistantMsg);
@@ -1646,25 +1660,33 @@ async function main(): Promise<void> {
 		let eaStats: RunStats;
 		let fastStats: RunStats | undefined;
 
-		if (order === "baseline-first") {
-			baselineStats = await runCodingAgent("baseline", config, mem, apiKey, budgetJ);
-			eaStats = await runCodingAgent("energy-aware", config, mem, apiKey, budgetJ);
-		} else {
-			eaStats = await runCodingAgent("energy-aware", config, mem, apiKey, budgetJ);
-			baselineStats = await runCodingAgent("baseline", config, mem, apiKey, budgetJ);
+		try {
+			if (order === "baseline-first") {
+				baselineStats = await runCodingAgent("baseline", config, mem, apiKey, budgetJ);
+				eaStats = await runCodingAgent("energy-aware", config, mem, apiKey, budgetJ);
+			} else {
+				eaStats = await runCodingAgent("energy-aware", config, mem, apiKey, budgetJ);
+				baselineStats = await runCodingAgent("baseline", config, mem, apiKey, budgetJ);
+			}
+
+			if (enableFast) {
+				fastStats = await runCodingAgent("fast", config, mem, apiKey, budgetJ);
+			}
+
+			const runLabel = numRuns > 1 ? `(Run ${i + 1}/${numRuns})` : "";
+			printScorecard(baselineStats, eaStats, config, budgetJ, runLabel, fastStats);
+
+			updateCodingMemory(mem, baselineStats, eaStats);
+			saveMemory(mem);
+
+			pairs.push({ runIndex: i, order, config, baseline: baselineStats, ea: eaStats, fast: fastStats });
+		} catch (err) {
+			console.error(
+				`\n  \x1b[31m✗ Run ${i + 1}/${numRuns} failed: ${err instanceof Error ? err.message : String(err)}\x1b[0m`,
+			);
+			if (numRuns === 1) throw err; // re-throw for single runs
+			console.log("  Skipping to next run…\n");
 		}
-
-		if (enableFast) {
-			fastStats = await runCodingAgent("fast", config, mem, apiKey, budgetJ);
-		}
-
-		const runLabel = numRuns > 1 ? `(Run ${i + 1}/${numRuns})` : "";
-		printScorecard(baselineStats, eaStats, config, budgetJ, runLabel, fastStats);
-
-		updateCodingMemory(mem, baselineStats, eaStats);
-		saveMemory(mem);
-
-		pairs.push({ runIndex: i, order, config, baseline: baselineStats, ea: eaStats, fast: fastStats });
 	}
 
 	if (numRuns > 1) {

--- a/packages/benchmarks/src/demos/coding-agent.ts
+++ b/packages/benchmarks/src/demos/coding-agent.ts
@@ -1592,6 +1592,7 @@ async function main(): Promise<void> {
 	}
 	console.log("╠══════════════════════════════════════════════════════════════════════╣");
 	console.log("║  Flags:  --runs N --reverse --budget N --static --fast --hard       ║");
+	console.log("║          --clear-memory                                             ║");
 	console.log("╚══════════════════════════════════════════════════════════════════════╝");
 
 	// Warn about energy telemetry source

--- a/packages/benchmarks/src/demos/coding-agent.ts
+++ b/packages/benchmarks/src/demos/coding-agent.ts
@@ -1138,11 +1138,16 @@ function printScorecard(
 
 	console.log("");
 	// Summary line for each mode — account for quality differences
+	const timeSaved = timeDelta < 0 ? Math.abs(timeDelta) : 0;
+	const fastTimeSaved =
+		hasFast && baseTime > 0 ? Math.max(0, ((baseTime - (fast.endTime - fast.startTime) / 1000) / baseTime) * 100) : 0;
+
 	const fmtSummary = (
 		label: string,
 		color: string,
 		saved: number,
 		costPct: number,
+		speedPct: number,
 		passed: boolean | undefined,
 		baselinePassed: boolean | undefined,
 	): void => {
@@ -1150,15 +1155,32 @@ function printScorecard(
 			console.log(`  \x1b[31m✗ ${label}: ${saved.toFixed(0)}% less energy but FAILED (baseline passed)\x1b[0m`);
 		} else if (saved > 0) {
 			const qualitySame = baselinePassed === true && passed === true ? " — same quality outcome" : "";
+			const speedStr = speedPct > 0 ? `, ${speedPct.toFixed(0)}% faster` : "";
 			console.log(
-				`  ${color}✓ ${label}: ${saved.toFixed(0)}% less energy, ${costPct.toFixed(0)}% lower cost${qualitySame}\x1b[0m`,
+				`  ${color}✓ ${label}: ${saved.toFixed(0)}% less energy, ${costPct.toFixed(0)}% lower cost${speedStr}${qualitySame}\x1b[0m`,
 			);
 		}
 	};
 
-	fmtSummary("Energy-aware", "\x1b[32m", energySaved, costSaved, energyAware.testPassed, baseline.testPassed);
+	fmtSummary(
+		"Energy-aware",
+		"\x1b[32m",
+		energySaved,
+		costSaved,
+		timeSaved,
+		energyAware.testPassed,
+		baseline.testPassed,
+	);
 	if (hasFast) {
-		fmtSummary("Fast mode", "\x1b[33m", fastEnergySaved, fastCostSaved, fast.testPassed, baseline.testPassed);
+		fmtSummary(
+			"Fast mode",
+			"\x1b[33m",
+			fastEnergySaved,
+			fastCostSaved,
+			fastTimeSaved,
+			fast.testPassed,
+			baseline.testPassed,
+		);
 	}
 }
 
@@ -1350,6 +1372,12 @@ function printAggregateScorecard(pairs: RunPair[]): void {
 	const avgEaCost = nPassed > 0 ? allPassed.reduce((s, p) => s + estimateCost(p.ea.turns), 0) / nPassed : 0;
 	const avgCostSavedPct = avgBaseCost > 0 ? ((avgBaseCost - avgEaCost) / avgBaseCost) * 100 : 0;
 
+	const avgBaseTime =
+		nPassed > 0 ? allPassed.reduce((s, p) => s + (p.baseline.endTime - p.baseline.startTime) / 1000, 0) / nPassed : 0;
+	const avgEaTime =
+		nPassed > 0 ? allPassed.reduce((s, p) => s + (p.ea.endTime - p.ea.startTime) / 1000, 0) / nPassed : 0;
+	const avgTimeSavedPct = avgBaseTime > 0 ? ((avgBaseTime - avgEaTime) / avgBaseTime) * 100 : 0;
+
 	// Fast aggregates (only all-passed runs)
 	const allPassedFast = allPassed.filter((p): p is RunPair & { fast: RunStats } => p.fast != null);
 	const avgFastEnergy =
@@ -1472,13 +1500,21 @@ function printAggregateScorecard(pairs: RunPair[]): void {
 			);
 		}
 		if (avgSavedPct > 0) {
+			const speedStr = avgTimeSavedPct > 0 ? `, ${avgTimeSavedPct.toFixed(0)}% faster` : "";
 			console.log(
-				`  \x1b[32m✓ Average energy savings: ${avgSavedPct.toFixed(0)}%, cost savings: ${avgCostSavedPct.toFixed(0)}%\x1b[0m`,
+				`  \x1b[32m✓ Average: ${avgSavedPct.toFixed(0)}% less energy, ${avgCostSavedPct.toFixed(0)}% lower cost${speedStr} — same quality outcome\x1b[0m`,
 			);
 		}
 		if (hasFast && avgFastSavedPct > 0) {
+			const avgFastTime =
+				allPassedFast.length > 0
+					? allPassedFast.reduce((s, p) => s + (p.fast.endTime - p.fast.startTime) / 1000, 0) /
+						allPassedFast.length
+					: 0;
+			const avgFastTimeSavedPct = avgBaseTime > 0 ? ((avgBaseTime - avgFastTime) / avgBaseTime) * 100 : 0;
+			const fastSpeedStr = avgFastTimeSavedPct > 0 ? `, ${avgFastTimeSavedPct.toFixed(0)}% faster` : "";
 			console.log(
-				`  \x1b[33m✓ Fast mode avg savings: ${avgFastSavedPct.toFixed(0)}% energy, ${avgFastCostSavedPct.toFixed(0)}% cost\x1b[0m`,
+				`  \x1b[33m✓ Fast mode avg: ${avgFastSavedPct.toFixed(0)}% less energy, ${avgFastCostSavedPct.toFixed(0)}% lower cost${fastSpeedStr}\x1b[0m`,
 			);
 		}
 	}

--- a/packages/benchmarks/src/demos/coding-agent.ts
+++ b/packages/benchmarks/src/demos/coding-agent.ts
@@ -59,21 +59,8 @@ import {
 
 // -- Models -------------------------------------------------------------------
 
-/**
- * Energy efficiency (tokens per joule) from portal.neuralwatt.com.
- * Used as fallback when the API does not return energy_joules.
- * Prefer API-reported energy_joules when available — these are approximations.
- */
-const TOKENS_PER_JOULE: Record<string, number> = {
-	"mistralai/Devstral-Small-2-24B-Instruct-2512": 22.35,
-	"Qwen/Qwen3.5-397B-A17B-FP8": 1.03,
-	"Qwen/Qwen3.5-35B-A3B": 27.51,
-	"openai/gpt-oss-20b": 0.5,
-	"moonshotai/Kimi-K2.5": 0.21,
-	"MiniMaxAI/MiniMax-M2.5": 0.5,
-	"kimi-k2.5-fast": 0.21,
-	"glm-5-fast": 0.5,
-};
+/** Track whether we've warned about missing energy telemetry this session. */
+let warnedMissingEnergy = false;
 
 /** Shared base for all NeuralWatt models. */
 const NW_BASE = {
@@ -187,7 +174,6 @@ const DISCRIMINATOR_CONFIG: DiscriminatorConfig = {
 	complex: { model: QWEN_MODEL },
 	medium: { model: DEVSTRAL_MODEL, briefMaxTokens: 4_096 },
 	simple: { model: GPT_OSS_MODEL, briefMaxTokens: 2_048 },
-	tokensPerJoule: TOKENS_PER_JOULE,
 	systemPrompt:
 		"You are a routing classifier for a four-tier coding AI system.\n" +
 		"Choose the CHEAPEST tier that can handle the task correctly:\n" +
@@ -501,8 +487,14 @@ const REPO_TSX = join(__dirname, "../../../../node_modules/.bin/tsx");
 function getEnergy(message: AssistantMessage, modelId: string): { joules: number; fromApi: boolean } {
 	const api = message.energy?.energy_joules;
 	if (api != null && api > 0) return { joules: api, fromApi: true };
-	const tokensPerJoule = TOKENS_PER_JOULE[modelId] ?? 1.0;
-	return { joules: message.usage.totalTokens / tokensPerJoule, fromApi: false };
+	if (!warnedMissingEnergy) {
+		warnedMissingEnergy = true;
+		console.error(
+			`\x1b[33m  ⚠ WARNING: No energy telemetry in API response for model "${modelId}".` +
+				`\n    Energy values will be reported as 0J. Use a Neuralwatt endpoint for accurate energy data.\x1b[0m`,
+		);
+	}
+	return { joules: 0, fromApi: false };
 }
 
 // -- Acceptance tests ---------------------------------------------------------
@@ -1565,6 +1557,17 @@ async function main(): Promise<void> {
 	console.log("╠══════════════════════════════════════════════════════════════════════╣");
 	console.log("║  Flags:  --runs N --reverse --budget N --static --fast --hard       ║");
 	console.log("╚══════════════════════════════════════════════════════════════════════╝");
+
+	// Warn about energy telemetry source
+	const allModels = [DEFAULT_MODEL, GPT_OSS_MODEL, DEVSTRAL_MODEL, QWEN_MODEL];
+	const nonNeuralwatt = allModels.filter((m) => m.provider !== "neuralwatt");
+	if (nonNeuralwatt.length > 0) {
+		console.log(
+			`\x1b[33m  ⚠ WARNING: ${nonNeuralwatt.length} model(s) are not from Neuralwatt and may not return` +
+				`\n    energy telemetry. Energy values for these models will be reported as 0J.` +
+				`\n    Models: ${nonNeuralwatt.map((m) => m.id).join(", ")}\x1b[0m`,
+		);
+	}
 
 	if (memSummary) {
 		console.log(memSummary);

--- a/packages/benchmarks/src/demos/coding-agent.ts
+++ b/packages/benchmarks/src/demos/coding-agent.ts
@@ -1478,6 +1478,17 @@ function printAggregateScorecard(pairs: RunPair[]): void {
 			console.log(
 				`  ${"est. cost".padEnd(taskCol)}  ${"".padEnd(10)}  ${`$${avgBaseCost.toFixed(4)}`.padEnd(10)}  ${`$${avgEaCost.toFixed(4)}`.padEnd(10)}  ${`$${avgFastCost.toFixed(4)}`.padEnd(10)}  ${`${avgCostSavedPct.toFixed(0)}%`.padEnd(6)}`,
 			);
+			const fmtTime = (s: number) => `${s.toFixed(0)}s`;
+			const fmtTimePct = (pct: number) => (pct > 0 ? `-${pct.toFixed(0)}%` : `+${Math.abs(pct).toFixed(0)}%`);
+			const avgFastTime =
+				allPassedFast.length > 0
+					? allPassedFast.reduce((s, p) => s + (p.fast.endTime - p.fast.startTime) / 1000, 0) /
+						allPassedFast.length
+					: 0;
+			const avgFastTimePct = avgBaseTime > 0 ? ((avgBaseTime - avgFastTime) / avgBaseTime) * 100 : 0;
+			console.log(
+				`  ${"wall time".padEnd(taskCol)}  ${"".padEnd(10)}  ${fmtTime(avgBaseTime).padEnd(10)}  ${`${fmtTime(avgEaTime)}  (${fmtTimePct(avgTimeSavedPct)})`.padEnd(10)}  ${`${fmtTime(avgFastTime)}  (${fmtTimePct(avgFastTimePct)})`.padEnd(10)}`,
+			);
 		}
 	} else {
 		console.log(
@@ -1492,6 +1503,11 @@ function printAggregateScorecard(pairs: RunPair[]): void {
 			);
 			console.log(
 				`  ${"est. cost".padEnd(taskCol)}  ${"".padEnd(10)}  ${`$${avgBaseCost.toFixed(4)}`.padEnd(10)}  ${`$${avgEaCost.toFixed(4)}`.padEnd(10)}  ${`${avgCostSavedPct.toFixed(0)}%`.padEnd(6)}`,
+			);
+			const fmtTime = (s: number) => `${s.toFixed(0)}s`;
+			const fmtTimePct = (pct: number) => (pct > 0 ? `-${pct.toFixed(0)}%` : `+${Math.abs(pct).toFixed(0)}%`);
+			console.log(
+				`  ${"wall time".padEnd(taskCol)}  ${"".padEnd(10)}  ${fmtTime(avgBaseTime).padEnd(10)}  ${`${fmtTime(avgEaTime)}  (${fmtTimePct(avgTimeSavedPct)})`.padEnd(10)}  ${`${avgTimeSavedPct.toFixed(0)}%`.padEnd(6)}`,
 			);
 		}
 	}

--- a/packages/benchmarks/src/demos/demo-discriminator.ts
+++ b/packages/benchmarks/src/demos/demo-discriminator.ts
@@ -62,11 +62,6 @@ export interface DiscriminatorConfig {
 	 * Recommended: GPT-OSS-20B (1.371 tok/J, most energy-efficient).
 	 */
 	simple: DiscriminatorTierConfig;
-	/**
-	 * Energy efficiency in tokens per joule per model id.
-	 * Used as a fallback when the API does not return energy_joules.
-	 */
-	tokensPerJoule: Record<string, number>;
 	/** System prompt override. Uses DEFAULT_DISCRIMINATOR_SYSTEM_PROMPT if not set. */
 	systemPrompt?: string;
 }
@@ -245,9 +240,7 @@ export async function discriminate(
 			.join("")
 			.trim();
 
-		const api = msg.energy?.energy_joules;
-		const tokensPerJoule = config.tokensPerJoule[config.classifierModel.id] ?? 1.0;
-		const energyJ = api != null && api > 0 ? api : msg.usage.totalTokens / tokensPerJoule;
+		const energyJ = msg.energy?.energy_joules ?? 0;
 
 		// Parse JSON from classifier response
 		let parsed: { tier?: string; length?: string; reason?: string } = {};

--- a/packages/benchmarks/src/demos/hn-watcher.ts
+++ b/packages/benchmarks/src/demos/hn-watcher.ts
@@ -840,15 +840,16 @@ async function main(): Promise<void> {
 		allowPositionals: true,
 	});
 
+	// Handle --clear-memory before anything else (no API key needed)
+	if (values["clear-memory"]) {
+		clearMemory();
+		console.log("Memory cleared (~/.energy-demo-memory.json deleted).");
+		process.exit(0);
+	}
+
 	if (!process.env.NEURALWATT_API_KEY) {
 		console.error("NEURALWATT_API_KEY required");
 		process.exit(1);
-	}
-
-	// Handle --clear-memory before anything else
-	if (values["clear-memory"]) {
-		clearMemory();
-		console.log("Memory cleared.");
 	}
 
 	const apiKey = process.env.NEURALWATT_API_KEY;

--- a/packages/benchmarks/src/demos/hn-watcher.ts
+++ b/packages/benchmarks/src/demos/hn-watcher.ts
@@ -130,14 +130,8 @@ const DEFAULT_BUDGET_JOULES = 50_000;
 /** Memory key for this routing pair. */
 const MEMORY_KEY = "kimi-k2.5→gpt-oss-20b";
 
-/** Energy efficiency (tokens per joule) from portal.neuralwatt.com. */
-const TOKENS_PER_JOULE: Record<string, number> = {
-	"mistralai/Devstral-Small-2-24B-Instruct-2512": 22.35,
-	"Qwen/Qwen3.5-397B-A17B-FP8": 1.03,
-	"openai/gpt-oss-20b": 0.5,
-	"moonshotai/Kimi-K2.5": 0.21,
-	"kimi-k2.5-fast": 0.21,
-};
+/** Track whether we've warned about missing energy telemetry this session. */
+let warnedMissingEnergy = false;
 
 /**
  * Discriminator config for the HN watcher.
@@ -154,7 +148,6 @@ const HN_DISCRIMINATOR_CONFIG: DiscriminatorConfig = {
 	complex: { model: DEVSTRAL_MODEL, briefMaxTokens: 8 }, // fallback if maxTier not applied
 	medium: { model: DEVSTRAL_MODEL, briefMaxTokens: 8 },
 	simple: { model: GPT_OSS_MODEL, briefMaxTokens: 8 },
-	tokensPerJoule: TOKENS_PER_JOULE,
 	systemPrompt:
 		"You are a routing classifier for a relevance-scoring pipeline.\n" +
 		"The task is always simple: score a HackerNews title's relevance to AI/ML as 0.0-1.0.\n" +
@@ -212,8 +205,14 @@ interface ScorePair {
 function getEnergy(message: AssistantMessage, modelId: string): number {
 	const api = message.energy?.energy_joules;
 	if (api != null && api > 0) return api;
-	const tokensPerJoule = TOKENS_PER_JOULE[modelId] ?? 1.0;
-	return message.usage.totalTokens / tokensPerJoule;
+	if (!warnedMissingEnergy) {
+		warnedMissingEnergy = true;
+		console.error(
+			`\x1b[33m  ⚠ WARNING: No energy telemetry in API response for model "${modelId}".` +
+				`\n    Energy values will be reported as 0J. Use a Neuralwatt endpoint for accurate energy data.\x1b[0m`,
+		);
+	}
+	return 0;
 }
 
 // -- HN API -------------------------------------------------------------------
@@ -886,6 +885,17 @@ async function main(): Promise<void> {
 
 	const topIds = await fetchTopStoryIds();
 	console.log(`Found ${topIds.length} stories. Running for ${durationS}s with ${budgetJ}J budget per run.\n`);
+
+	// Warn about non-Neuralwatt models
+	const allModels = [GPT_OSS_MODEL, DEVSTRAL_MODEL];
+	const nonNeuralwatt = allModels.filter((m) => m.provider !== "neuralwatt");
+	if (nonNeuralwatt.length > 0) {
+		console.log(
+			`\x1b[33m  ⚠ WARNING: ${nonNeuralwatt.length} model(s) are not from Neuralwatt and may not return` +
+				`\n    energy telemetry. Energy values for these models will be reported as 0J.` +
+				`\n    Models: ${nonNeuralwatt.map((m) => m.id).join(", ")}\x1b[0m\n`,
+		);
+	}
 
 	const baselinePolicy = new BaselinePolicy();
 	const energyAwarePolicy = new EnergyAwarePolicy();

--- a/packages/benchmarks/test/cli-args.test.ts
+++ b/packages/benchmarks/test/cli-args.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for CLI argument parsing in both demos.
+ *
+ * These verify that parseArgs is configured correctly and that all
+ * documented flags are recognized. This catches issues like npm
+ * swallowing flags (users must use `--` separator with `npm run`).
+ */
+
+import { parseArgs } from "node:util";
+import { describe, expect, it } from "vitest";
+
+// -- Coding demo arg spec (mirrors coding-agent.ts main()) --------------------
+
+const CODING_DEMO_OPTIONS = {
+	budget: { type: "string" as const, default: "25000" },
+	task: { type: "string" as const },
+	acceptance: { type: "string" as const },
+	static: { type: "boolean" as const, default: false },
+	reverse: { type: "boolean" as const, default: false },
+	runs: { type: "string" as const, default: "1" },
+	fast: { type: "boolean" as const, default: false },
+	hard: { type: "boolean" as const, default: false },
+	"clear-memory": { type: "boolean" as const, default: false },
+};
+
+function parseCodingArgs(argv: string[]) {
+	return parseArgs({ options: CODING_DEMO_OPTIONS, allowPositionals: true, args: argv });
+}
+
+// -- HN demo arg spec (mirrors hn-watcher.ts main()) -------------------------
+
+const HN_DEMO_OPTIONS = {
+	duration: { type: "string" as const, default: "180" },
+	budget: { type: "string" as const, default: "5000" },
+	keywords: { type: "string" as const },
+	fast: { type: "boolean" as const, default: false },
+	"clear-memory": { type: "boolean" as const, default: false },
+};
+
+function parseHNArgs(argv: string[]) {
+	return parseArgs({ options: HN_DEMO_OPTIONS, allowPositionals: true, args: argv });
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("coding demo CLI args", () => {
+	it("defaults: 1 run, 25000J budget, no flags", () => {
+		const { values } = parseCodingArgs([]);
+		expect(values.runs).toBe("1");
+		expect(values.budget).toBe("25000");
+		expect(values.static).toBe(false);
+		expect(values.reverse).toBe(false);
+		expect(values.fast).toBe(false);
+		expect(values.hard).toBe(false);
+		expect(values["clear-memory"]).toBe(false);
+	});
+
+	it("--runs 4 sets 4 runs", () => {
+		const { values } = parseCodingArgs(["--runs", "4"]);
+		expect(values.runs).toBe("4");
+	});
+
+	it("--budget 50000 overrides budget", () => {
+		const { values } = parseCodingArgs(["--budget", "50000"]);
+		expect(values.budget).toBe("50000");
+	});
+
+	it("--static enables static mode", () => {
+		const { values } = parseCodingArgs(["--static"]);
+		expect(values.static).toBe(true);
+	});
+
+	it("--reverse enables reverse order", () => {
+		const { values } = parseCodingArgs(["--reverse"]);
+		expect(values.reverse).toBe(true);
+	});
+
+	it("--fast enables fast mode", () => {
+		const { values } = parseCodingArgs(["--fast"]);
+		expect(values.fast).toBe(true);
+	});
+
+	it("--hard enables hard challenges", () => {
+		const { values } = parseCodingArgs(["--hard"]);
+		expect(values.hard).toBe(true);
+	});
+
+	it("--clear-memory sets clear flag", () => {
+		const { values } = parseCodingArgs(["--clear-memory"]);
+		expect(values["clear-memory"]).toBe(true);
+	});
+
+	it("--task provides custom task", () => {
+		const { values } = parseCodingArgs(["--task", "implement fizzbuzz"]);
+		expect(values.task).toBe("implement fizzbuzz");
+	});
+
+	it("multiple flags combined", () => {
+		const { values } = parseCodingArgs(["--runs", "3", "--reverse", "--hard", "--budget", "10000"]);
+		expect(values.runs).toBe("3");
+		expect(values.reverse).toBe(true);
+		expect(values.hard).toBe(true);
+		expect(values.budget).toBe("10000");
+	});
+
+	it("positional args are allowed (don't throw)", () => {
+		const { positionals } = parseCodingArgs(["some-positional"]);
+		expect(positionals).toContain("some-positional");
+	});
+
+	it("unknown flags throw", () => {
+		expect(() => parseCodingArgs(["--unknown-flag"])).toThrow();
+	});
+});
+
+describe("HN demo CLI args", () => {
+	it("defaults: 180s duration, 5000J budget", () => {
+		const { values } = parseHNArgs([]);
+		expect(values.duration).toBe("180");
+		expect(values.budget).toBe("5000");
+		expect(values.fast).toBe(false);
+		expect(values["clear-memory"]).toBe(false);
+	});
+
+	it("--duration 60 overrides duration", () => {
+		const { values } = parseHNArgs(["--duration", "60"]);
+		expect(values.duration).toBe("60");
+	});
+
+	it("--budget 10000 overrides budget", () => {
+		const { values } = parseHNArgs(["--budget", "10000"]);
+		expect(values.budget).toBe("10000");
+	});
+
+	it("--keywords overrides keywords", () => {
+		const { values } = parseHNArgs(["--keywords", "rust,wasm,zig"]);
+		expect(values.keywords).toBe("rust,wasm,zig");
+	});
+
+	it("--fast enables fast mode", () => {
+		const { values } = parseHNArgs(["--fast"]);
+		expect(values.fast).toBe(true);
+	});
+
+	it("--clear-memory sets clear flag", () => {
+		const { values } = parseHNArgs(["--clear-memory"]);
+		expect(values["clear-memory"]).toBe(true);
+	});
+
+	it("multiple flags combined", () => {
+		const { values } = parseHNArgs(["--duration", "30", "--budget", "2000", "--fast"]);
+		expect(values.duration).toBe("30");
+		expect(values.budget).toBe("2000");
+		expect(values.fast).toBe(true);
+	});
+});

--- a/packages/benchmarks/test/discriminator.test.ts
+++ b/packages/benchmarks/test/discriminator.test.ts
@@ -28,7 +28,6 @@ function fullConfig(): DiscriminatorConfig {
 		complex: { model: mockModel("complex-model", "Complex", ["tool_calling"]) },
 		medium: { model: mockModel("medium-model", "Medium", ["tool_calling"]), briefMaxTokens: 4_096 },
 		simple: { model: mockModel("simple-model", "Simple", []), briefMaxTokens: 2_048 },
-		tokensPerJoule: { classifier: 1.0 },
 	};
 }
 
@@ -38,7 +37,6 @@ function minimalConfig(): DiscriminatorConfig {
 		classifierModel: mockModel("classifier", "Classifier"),
 		complex: { model: mockModel("complex-model", "Complex", ["tool_calling"]) },
 		simple: { model: mockModel("simple-model", "Simple", []) },
-		tokensPerJoule: {},
 	};
 }
 
@@ -184,7 +182,6 @@ describe("discriminate — requires: tool_calling", () => {
 			classifierModel: mockModel("classifier", "Classifier"),
 			complex: { model: mockModel("complex-model", "Complex", []) },
 			simple: { model: mockModel("simple-model", "Simple", []) },
-			tokensPerJoule: {},
 		};
 		const result = await discriminate("test", "hello", config, "", "key", {
 			requires: ["tool_calling"],
@@ -241,7 +238,6 @@ describe("discriminate — fallback chain ordering", () => {
 			complex: { model: mockModel("complex-model", "Complex", []) },
 			medium: { model: mockModel("medium-model", "Medium", []) },
 			simple: { model: mockModel("simple-model", "Simple", []) },
-			tokensPerJoule: {},
 		};
 		const result = await discriminate("test", "hello", config, "", "key", {
 			requires: ["tool_calling"],
@@ -258,7 +254,6 @@ describe("discriminate — fallback chain ordering", () => {
 			complex: { model: mockModel("complex-model", "Complex", []) },
 			medium: { model: mockModel("medium-model", "Medium", []) },
 			simple: { model: mockModel("simple-model", "Simple", ["tool_calling"]) },
-			tokensPerJoule: {},
 		};
 		const result = await discriminate("test", "hello", config, "", "key", {
 			requires: ["tool_calling"],
@@ -276,7 +271,6 @@ describe("discriminate — fallback chain ordering", () => {
 			complex: { model: mockModel("complex-model", "Complex", ["tool_calling"]) },
 			medium: { model: mockModel("medium-model", "Medium", []) },
 			simple: { model: mockModel("simple-model", "Simple", []) },
-			tokensPerJoule: {},
 		};
 		const result = await discriminate("test", "hello", config, "", "key", {
 			requires: ["tool_calling"],
@@ -294,7 +288,6 @@ describe("discriminate — fallback chain ordering", () => {
 			complex: { model: mockModel("complex-model", "Complex", []) },
 			medium: { model: mockModel("medium-model", "Medium", ["tool_calling"]) },
 			simple: { model: mockModel("simple-model", "Simple", []) },
-			tokensPerJoule: {},
 		};
 		const result = await discriminate("test", "hello", config, "", "key", {
 			requires: ["tool_calling"],
@@ -317,7 +310,6 @@ describe("discriminate — models without capabilities field", () => {
 			simple: {
 				model: { ...mockModel("simple-model", "Simple"), capabilities: undefined } as Model<"openai-completions">,
 			},
-			tokensPerJoule: {},
 		};
 		// Without requires, undefined capabilities should work fine
 		const result = await discriminate("test", "hello", config, "", "key");
@@ -332,7 +324,6 @@ describe("discriminate — models without capabilities field", () => {
 			simple: {
 				model: { ...mockModel("simple-model", "Simple"), capabilities: undefined } as Model<"openai-completions">,
 			},
-			tokensPerJoule: {},
 		};
 		const result = await discriminate("test", "hello", config, "", "key", {
 			requires: ["tool_calling"],
@@ -455,12 +446,6 @@ describe("discriminate — Fugue tool_calling scenario", () => {
 				briefMaxTokens: 4_096,
 			},
 			simple: { model: mockModel("openai/gpt-oss-20b", "GPT-OSS 20B", []), briefMaxTokens: 2_048 },
-			tokensPerJoule: {
-				"openai/gpt-oss-20b": 0.5,
-				"mistralai/Devstral-Small-2-24B-Instruct-2512": 9.92,
-				"moonshotai/Kimi-K2.5": 0.21,
-				"Qwen/Qwen3.5-397B-A17B-FP8": 1.03,
-			},
 		};
 	}
 

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,5 +1,11 @@
 import { join } from "node:path";
-import { Agent, type AgentMessage, type ThinkingLevel } from "@mariozechner/pi-agent-core";
+import {
+	Agent,
+	type AgentMessage,
+	type EnergyBudget,
+	type RuntimePolicy,
+	type ThinkingLevel,
+} from "@mariozechner/pi-agent-core";
 import type { Message, Model } from "@mariozechner/pi-ai";
 import { getAgentDir, getDocsPath } from "../config.js";
 import { AgentSession } from "./agent-session.js";
@@ -69,6 +75,15 @@ export interface CreateAgentSessionOptions {
 
 	/** Settings manager. Default: SettingsManager.create(cwd, agentDir) */
 	settingsManager?: SettingsManager;
+
+	/** Optional runtime policy for energy-aware budgeting. */
+	policy?: RuntimePolicy;
+	/** Models available for policy-driven model routing, sorted by cost.output ascending. */
+	availableModels?: Model<any>[];
+	/** Energy/time budget for policy-driven budget enforcement. */
+	budget?: EnergyBudget;
+	/** Called when the policy requests context compaction. */
+	onCompact?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
 }
 
 /** Result from createAgentSession */
@@ -83,6 +98,8 @@ export interface CreateAgentSessionResult {
 
 // Re-exports
 
+export type { EnergyBudget, RuntimePolicy } from "@mariozechner/pi-agent-core";
+export type { EnergyUsage } from "@mariozechner/pi-ai";
 export type {
 	ExtensionAPI,
 	ExtensionCommandContext,
@@ -310,6 +327,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		transport: settingsManager.getTransport(),
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
 		maxRetryDelayMs: settingsManager.getRetrySettings().maxDelayMs,
+		policy: options.policy,
+		availableModels: options.availableModels,
+		budget: options.budget,
+		onCompact: options.onCompact,
 		getApiKey: async (provider) => {
 			// Use the provider argument from the in-flight request;
 			// agent.state.model may already be switched mid-turn.

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -171,7 +171,11 @@ export {
 	createReadOnlyTools,
 	createReadTool,
 	createWriteTool,
+	// Energy-aware types (re-exported from pi-agent-core / pi-ai)
+	type EnergyBudget,
+	type EnergyUsage,
 	type PromptTemplate,
+	type RuntimePolicy,
 	// Pre-built tools (use process.cwd())
 	readOnlyTools,
 } from "./core/sdk.js";


### PR DESCRIPTION
## Summary

- **Pi-mono preparatory work (P1-P8)** for openclaw integration — all complete
- **SSE energy telemetry fix** — Neuralwatt returns energy as SSE comment lines (`: energy {...}`), which the OpenAI SDK silently drops. Added a custom fetch wrapper that captures these before the SDK parses the response.
- **Removed `TOKENS_PER_JOULE` lookup table** — demos now use real API energy telemetry exclusively, with a warning when energy data is missing
- **Documentation overhaul** — rewrote `ENERGY_AWARENESS.md` as full implementation reference, added Quickstart, updated README with upstream diff table and demo commands
- **Demo improvements** — speed diff in summaries, wall time in aggregate table, retry logic with backoff, per-run error handling for multi-run mode, `--clear-memory` fix, CLI arg tests

## Changes by package

| Package | Changes |
|---------|---------|
| `packages/ai` | `buildAssistantMessage()` helper, SSE comment energy capture via custom fetch wrapper, `EnergyUsage` import |
| `packages/agent` | `onCompact` callback on `AgentLoopConfig` + agent loop wiring, policy/budget/availableModels on `Agent` class + `AgentOptions`, runtime accessors |
| `packages/coding-agent` | `createAgentSession` accepts policy config, re-exports `EnergyBudget`/`RuntimePolicy`/`EnergyUsage` |
| `packages/benchmarks` | Removed lookup table, startup warnings, speed in summaries, wall time in aggregate, retry logic, `--clear-memory` fix, CLI arg tests (19 new) |
| Root docs | `ENERGY_AWARENESS.md` rewrite, `OPENCLAW_INTEGRATION.md`, `README.md` updates |

## Test plan

- [x] `npm run check` passes clean (0 errors)
- [x] `packages/ai` — 67 tests pass
- [x] `packages/agent` — 90 tests pass
- [x] `packages/benchmarks` — 107 tests pass (19 new CLI arg tests)
- [x] Verified real energy telemetry with Neuralwatt API (GPT-OSS-20B, Kimi K2.5)
- [x] Coding demo: 4-run session, all pass, 95% avg energy savings with `[api]` tags
- [x] HN demo: 30s run, 97% energy savings with `[api]` tags
- [ ] Run on CI

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)