### PR TITLE
feat: add timing-breakdown extension

### DIFF
--- a/packages/coding-agent/examples/extensions/timing-breakdown/index.ts
+++ b/packages/coding-agent/examples/extensions/timing-breakdown/index.ts
@@ -1,18 +1,23 @@
 /**
  * Timing Breakdown Extension
  *
- * Tracks wall-clock time spent in LLM requests vs tool calls vs overhead,
- * with per-tool and per-turn breakdowns.
+ * Tracks wall-clock time, token throughput, cache efficiency, context size,
+ * energy usage, and tool output sizes — everything needed to identify
+ * optimization targets.
+ *
+ * Assumes Neuralwatt provider endpoints that return energy telemetry
+ * (energy_joules, energy_kwh, duration_seconds) in the usage object.
  *
  * Commands:
  *   /timing        — Show timing summary for the last prompt
  *   /timing full   — Show detailed per-turn and per-tool breakdown
+ *   /timing opt    — Show optimization opportunities analysis
  *   /timing reset  — Clear accumulated timing data
  *   /timing watch  — Toggle auto-display after each agent_end
- *
- * Also shows a compact timing line in the footer that updates live.
+ *   /timing footer — Toggle live timing in footer
  */
 
+import type { AssistantMessage, EnergyUsage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
@@ -23,33 +28,59 @@ interface RequestTiming {
 	ttfb?: number; // ms to first byte (after_provider_response)
 	end: number; // Date.now() when assistant message_end fires
 	turnIndex: number;
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	costTotal: number;
+	energy?: EnergyUsage;
+	model: string;
+	responseModel?: string;
+	status?: number; // HTTP status from after_provider_response
+	retryCount: number;
+	wasRateLimited: boolean;
+	diagnosticsCount: number;
 }
 
 interface ToolTiming {
 	toolCallId: string;
 	name: string;
-	start: number; // Date.now() at tool_execution_start
-	end: number; // Date.now() at tool_execution_end
+	start: number;
+	end: number;
 	isError: boolean;
 	turnIndex: number;
+	outputSize: number; // bytes of tool result content
+	argsSummary: string; // short description of args for optimization hints
 }
 
 interface TurnTiming {
 	index: number;
-	start: number; // turn_start timestamp
-	end: number; // turn_end timestamp
+	start: number;
+	end: number;
 	requestStart?: number;
 	requestTtfb?: number;
 	requestEnd?: number;
 	tools: ToolTiming[];
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+}
+
+interface CompactionTiming {
+	timestamp: number;
+	tokensBefore: number;
 }
 
 interface PromptTiming {
-	promptStart: number; // agent_start
-	promptEnd: number; // agent_end
+	promptStart: number;
+	promptEnd: number;
 	turns: TurnTiming[];
 	requests: RequestTiming[];
 	tools: ToolTiming[];
+	compactions: CompactionTiming[];
+	// Context size snapshot from each context event
+	contextSizes: { turnIndex: number; messageCount: number; timestamp: number }[];
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -62,15 +93,47 @@ function fmt(ms: number): string {
 	return `${mins}m${secs}s`;
 }
 
+function fmtTokens(n: number): string {
+	if (n < 1000) return `${n}`;
+	if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+	return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
 function pct(part: number, whole: number): string {
 	if (whole === 0) return "0%";
 	return `${Math.round((part / whole) * 100)}%`;
 }
 
 function bar(part: number, whole: number, width = 20): string {
-	if (whole === 0) return " ".repeat(width);
+	if (whole === 0) return "░".repeat(width);
 	const filled = Math.round((part / whole) * width);
 	return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+function fmtEnergy(energy?: EnergyUsage): string {
+	if (!energy) return "";
+	const j = energy.energy_joules;
+	if (j < 1) return `${(j * 1000).toFixed(0)}mJ`;
+	if (j < 1000) return `${j.toFixed(1)}J`;
+	return `${(j / 1000).toFixed(2)}kJ`;
+}
+
+function fmtBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes}B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function contentSize(content: unknown): number {
+	if (typeof content === "string") return Buffer.byteLength(content, "utf8");
+	if (Array.isArray(content)) {
+		return content.reduce((sum: number, block: any) => {
+			if (block.type === "text") return sum + Buffer.byteLength(block.text || "", "utf8");
+			if (block.type === "image") return sum + (block.data?.length || 0) * 0.75; // base64 ≈ 75% overhead
+			return sum;
+		}, 0);
+	}
+	return 0;
 }
 
 // ── Extension ───────────────────────────────────────────────────────
@@ -80,12 +143,16 @@ export default function (pi: ExtensionAPI) {
 	let history: PromptTiming[] = [];
 	let autoShow = false;
 	let footerEnabled = false;
-
-	// ── Accumulator for in-flight request tracking ──
-
-	// We track pending requests by turn to handle multi-turn flows
-	const pendingRequests = new Map<number, number>(); // turnIndex -> request start time
 	let currentTurnIndex = 0;
+
+	// Track per-turn request state for matching message_end to request
+	const pendingRequests = new Map<number, RequestTiming>();
+	// Track retries by counting duplicate before_provider_request per turn
+	const requestCountPerTurn = new Map<number, number>();
+	// Track rate limit responses
+	const rateLimitedTurns = new Set<number>();
+	// Track tool output sizes from tool_result events
+	const toolOutputSizes = new Map<string, number>();
 
 	// ── Agent lifecycle ──
 
@@ -96,25 +163,23 @@ export default function (pi: ExtensionAPI) {
 			turns: [],
 			requests: [],
 			tools: [],
+			compactions: [],
+			contextSizes: [],
 		};
 		currentTurnIndex = 0;
 		pendingRequests.clear();
-		if (footerEnabled) {
-			pi.sendUserMessage("/timing footer-on", { deliverAs: "followUp" });
-		}
+		requestCountPerTurn.clear();
+		rateLimitedTurns.clear();
+		toolOutputSizes.clear();
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
 		if (!current) return;
 		current.promptEnd = Date.now();
 		history.push(current);
-
-		// Keep only last 20 prompts
-		if (history.length > 20) history = history.slice(-20);
-
+		if (history.length > 50) history = history.slice(-50);
 		if (autoShow) {
-			const summary = formatSummary(current);
-			ctx.ui.notify(summary, "info");
+			ctx.ui.notify(formatSummary(current), "info");
 		}
 	});
 
@@ -128,6 +193,10 @@ export default function (pi: ExtensionAPI) {
 			start: Date.now(),
 			end: 0,
 			tools: [],
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
 		});
 	});
 
@@ -137,47 +206,92 @@ export default function (pi: ExtensionAPI) {
 		if (turn) turn.end = Date.now();
 	});
 
+	// ── Context size estimation ──
+
+	pi.on("context", async (event) => {
+		if (!current) return;
+		current.contextSizes.push({
+			turnIndex: currentTurnIndex,
+			messageCount: event.messages.length,
+			timestamp: Date.now(),
+		});
+	});
+
 	// ── Provider request tracking ──
 
 	pi.on("before_provider_request", async () => {
 		if (!current) return;
 		const start = Date.now();
-		pendingRequests.set(currentTurnIndex, start);
-		current.requests.push({
+		const existingCount = requestCountPerTurn.get(currentTurnIndex) ?? 0;
+		requestCountPerTurn.set(currentTurnIndex, existingCount + 1);
+
+		const req: RequestTiming = {
 			start,
 			end: 0,
 			turnIndex: currentTurnIndex,
-		});
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			costTotal: 0,
+			model: "",
+			retryCount: existingCount, // If this is the 2nd+ request for this turn, it's a retry
+			wasRateLimited: rateLimitedTurns.has(currentTurnIndex),
+			diagnosticsCount: 0,
+		};
+		current.requests.push(req);
+		pendingRequests.set(currentTurnIndex, req);
 	});
 
-	pi.on("after_provider_response", async () => {
+	pi.on("after_provider_response", async (event) => {
 		if (!current) return;
 		const now = Date.now();
-		const req = [...current.requests].reverse().find((r) => r.end === 0);
+		const req = pendingRequests.get(currentTurnIndex);
 		if (req) {
 			req.ttfb = now - req.start;
+			req.status = event.status;
 		}
-		// Update turn's request timing
-		const turn = current.turns.find((t) => t.index === req?.turnIndex);
+		const turn = current.turns.find((t) => t.index === currentTurnIndex);
 		if (turn && req) {
 			turn.requestStart = req.start;
 			turn.requestTtfb = req.ttfb;
+		}
+		// Track rate limits for next request in this turn
+		if (event.status === 429) {
+			rateLimitedTurns.add(currentTurnIndex);
 		}
 	});
 
 	pi.on("message_end", async (event) => {
 		if (!current) return;
 		if (event.message.role !== "assistant") return;
+		const msg = event.message as AssistantMessage;
 		const now = Date.now();
-		// Close the most recent open request
-		const req = [...current.requests].reverse().find((r) => r.end === 0);
+
+		// Close the request for this turn
+		const req = pendingRequests.get(currentTurnIndex);
 		if (req) {
 			req.end = now;
+			req.inputTokens = msg.usage.input;
+			req.outputTokens = msg.usage.output;
+			req.cacheReadTokens = msg.usage.cacheRead;
+			req.cacheWriteTokens = msg.usage.cacheWrite;
+			req.costTotal = msg.usage.cost.total;
+			req.energy = msg.energy;
+			req.model = msg.model;
+			req.responseModel = msg.responseModel;
+			req.diagnosticsCount = msg.diagnostics?.length ?? 0;
+			pendingRequests.delete(currentTurnIndex);
 		}
-		// Update turn's request end
-		const turn = current.turns.find((t) => t.index === req?.turnIndex);
-		if (turn && req) {
+
+		// Update turn token/energy summary
+		const turn = current.turns.find((t) => t.index === currentTurnIndex);
+		if (turn) {
 			turn.requestEnd = now;
+			turn.inputTokens += msg.usage.input;
+			turn.outputTokens += msg.usage.output;
+			turn.cacheReadTokens += msg.usage.cacheRead;
+			turn.cacheWriteTokens += msg.usage.cacheWrite;
 		}
 	});
 
@@ -185,19 +299,20 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("tool_execution_start", async (event) => {
 		if (!current) return;
-		current.tools.push({
+		const argsSummary = formatArgsSummary(event.toolName, event.args);
+		const t: ToolTiming = {
 			toolCallId: event.toolCallId,
 			name: event.toolName,
 			start: Date.now(),
 			end: 0,
 			isError: false,
 			turnIndex: currentTurnIndex,
-		});
-		// Also push to the current turn
+			outputSize: 0,
+			argsSummary,
+		};
+		current.tools.push(t);
 		const turn = current.turns.find((t) => t.index === currentTurnIndex);
-		if (turn) {
-			turn.tools.push(current.tools[current.tools.length - 1]);
-		}
+		if (turn) turn.tools.push(t);
 	});
 
 	pi.on("tool_execution_end", async (event) => {
@@ -207,9 +322,56 @@ export default function (pi: ExtensionAPI) {
 			t.end = Date.now();
 			t.isError = event.isError;
 		}
+		// Capture output size from result
+		const existingSize = toolOutputSizes.get(event.toolCallId) ?? 0;
+		if (t) t.outputSize = existingSize || contentSize(event.result);
 	});
 
-	// ── Formatting ──
+	// Also capture output size from tool_result events (more accurate content sizing)
+	pi.on("tool_result", async (event) => {
+		const size = contentSize(event.content);
+		toolOutputSizes.set(event.toolCallId, size);
+		// Backfill the tool timing if it exists
+		if (current) {
+			const t = current.tools.find((t) => t.toolCallId === event.toolCallId);
+			if (t) t.outputSize = size;
+		}
+	});
+
+	// ── Compaction tracking ──
+
+	pi.on("session_compact", async (event) => {
+		if (!current) return;
+		current.compactions.push({
+			timestamp: Date.now(),
+			tokensBefore: event.compactionEntry.tokensBefore,
+		});
+	});
+
+	// ── Args summary for optimization hints ──
+
+	function formatArgsSummary(toolName: string, args: any): string {
+		try {
+			switch (toolName) {
+				case "bash":
+					return String(args.command || "").slice(0, 60);
+				case "read":
+					return String(args.file_path || args.path || "");
+				case "write":
+					return `${String(args.file_path || args.path || "")} (${String(args.content || "").split("\n").length} lines)`;
+				case "edit":
+					return String(args.file_path || args.path || "");
+				default:
+					return "";
+			}
+		} catch {
+			return "";
+		}
+	}
+
+	// ══════════════════════════════════════════════════════════════════
+	// Formatting
+	// ══════════════════════════════════════════════════════════════════
 
 	function formatSummary(t: PromptTiming): string {
 		const total = t.promptEnd - t.promptStart;
@@ -218,18 +380,44 @@ export default function (pi: ExtensionAPI) {
 		const llmTime = t.requests.reduce((s, r) => s + (r.end - r.start), 0);
 		const toolTime = t.tools.reduce((s, r) => s + (r.end - r.start), 0);
 		const overhead = total - llmTime - toolTime;
-		const turns = t.turns.length;
-		const toolCalls = t.tools.length;
+		const totalInput = t.requests.reduce((s, r) => s + r.inputTokens, 0);
+		const totalOutput = t.requests.reduce((s, r) => s + r.outputTokens, 0);
+		const totalCacheRead = t.requests.reduce((s, r) => s + r.cacheReadTokens, 0);
+		const totalCacheWrite = t.requests.reduce((s, r) => s + r.cacheWriteTokens, 0);
+		const totalCost = t.requests.reduce((s, r) => s + r.costTotal, 0);
+		const totalEnergy = t.requests.reduce((s, r) => s + (r.energy?.energy_joules ?? 0), 0);
+		const cacheHitRate = totalCacheRead > 0 ? Math.round((totalCacheRead / (totalInput || 1)) * 100) : 0;
+		const outputTokPerSec = llmTime > 0 ? Math.round(totalOutput / (llmTime / 1000)) : 0;
+		const retries = t.requests.filter((r) => r.retryCount > 0).length;
+		const rateLimits = t.requests.filter((r) => r.wasRateLimited).length;
 
 		const lines: string[] = [];
 		lines.push(
 			`⏱  ${fmt(total)} total │ ${fmt(llmTime)} LLM (${pct(llmTime, total)}) │ ${fmt(toolTime)} tools (${pct(toolTime, total)}) │ ${fmt(overhead)} overhead (${pct(overhead, total)})`,
 		);
-		lines.push(`   ${turns} turn${turns !== 1 ? "s" : ""} │ ${toolCalls} tool call${toolCalls !== 1 ? "s" : ""}`);
+		lines.push(
+			`   ${t.turns.length} turn${t.turns.length !== 1 ? "s" : ""} │ ${t.tools.length} tool call${t.tools.length !== 1 ? "s" : ""} │ ${fmtTokens(totalInput)} in │ ${fmtTokens(totalOutput)} out │ ${outputTokPerSec > 0 ? `${outputTokPerSec} tok/s` : "—"} out`,
+		);
 
-		if (t.requests.length > 0) {
-			const avgTtfb = t.requests.reduce((s, r) => s + (r.ttfb ?? 0), 0) / t.requests.length;
-			lines.push(`   TTFB: ${fmt(avgTtfb)} avg`);
+		if (totalCacheRead > 0 || totalCacheWrite > 0) {
+			lines.push(
+				`   Cache: ${fmtTokens(totalCacheRead)} read (${cacheHitRate}% hit) │ ${fmtTokens(totalCacheWrite)} write`,
+			);
+		}
+		if (totalCost > 0) lines.push(`   Cost: $${totalCost.toFixed(4)}`);
+		if (totalEnergy > 0)
+			lines.push(
+				`   Energy: ${fmtEnergy({ energy_joules: totalEnergy, energy_kwh: totalEnergy / 3_600_000, duration_seconds: 0 })}`,
+			);
+		if (retries > 0) lines.push(`   ⚠ Retries: ${retries}`);
+		if (rateLimits > 0) lines.push(`   ⚠ Rate limited: ${rateLimits}`);
+		if (t.compactions.length > 0)
+			lines.push(
+				`   🗜 Compactions: ${t.compactions.length} (last: ${fmtTokens(t.compactions[t.compactions.length - 1].tokensBefore)} before)`,
+			);
+		const totalToolOutput = t.tools.reduce((s, t) => s + t.outputSize, 0);
+		if (totalToolOutput > 10 * 1024) {
+			lines.push(`   📦 Tool output: ${fmtBytes(totalToolOutput)}`);
 		}
 
 		return lines.join("\n");
@@ -241,56 +429,104 @@ export default function (pi: ExtensionAPI) {
 
 		const llmTime = t.requests.reduce((s, r) => s + (r.end - r.start), 0);
 		const toolTime = t.tools.reduce((s, r) => s + (r.end - r.start), 0);
-		const overhead = total - llmTime - toolTime;
+		const overhead = Math.max(0, total - llmTime - toolTime);
+		const totalInput = t.requests.reduce((s, r) => s + r.inputTokens, 0);
+		const totalOutput = t.requests.reduce((s, r) => s + r.outputTokens, 0);
+		const totalCacheRead = t.requests.reduce((s, r) => s + r.cacheReadTokens, 0);
+		const totalCacheWrite = t.requests.reduce((s, r) => s + r.cacheWriteTokens, 0);
+		const totalCost = t.requests.reduce((s, r) => s + r.costTotal, 0);
+		const totalEnergy = t.requests.reduce((s, r) => s + (r.energy?.energy_joules ?? 0), 0);
+		const cacheHitRate = totalCacheRead > 0 ? Math.round((totalCacheRead / (totalInput || 1)) * 100) : 0;
+		const outputTokPerSec = llmTime > 0 ? Math.round(totalOutput / (llmTime / 1000)) : 0;
 
 		const lines: string[] = [];
 
-		// ── Header: overall breakdown ──
+		// ── Header ──
 		lines.push("");
-		lines.push("╭─────────────────────────────────────────────────────────╮");
-		lines.push("│  TIMING BREAKDOWN                                       │");
-		lines.push("╰─────────────────────────────────────────────────────────╯");
+		lines.push("╭──────────────────────────────────────────────────────────╮");
+		lines.push("│  TIMING BREAKDOWN                                        │");
+		lines.push("╰──────────────────────────────────────────────────────────╯");
 		lines.push("");
 		lines.push(`  Total: ${fmt(total)}`);
 		lines.push("");
-		lines.push(`  LLM requests  ${bar(llmTime, total)} ${fmt(llmTime)} (${pct(llmTime, total)})`);
-		lines.push(`  Tool calls     ${bar(toolTime, total)} ${fmt(toolTime)} (${pct(toolTime, total)})`);
-		lines.push(
-			`  Overhead       ${bar(Math.max(0, overhead), total)} ${fmt(Math.max(0, overhead))} (${pct(Math.max(0, overhead), total)})`,
-		);
+		lines.push(`  LLM requests  ${bar(llmTime, total)}  ${fmt(llmTime)} (${pct(llmTime, total)})`);
+		lines.push(`  Tool calls     ${bar(toolTime, total)}  ${fmt(toolTime)} (${pct(toolTime, total)})`);
+		lines.push(`  Overhead       ${bar(overhead, total)}  ${fmt(overhead)} (${pct(overhead, total)})`);
+		lines.push("");
+
+		// ── Token & cost summary ──
+		lines.push("  ── Tokens & Cost ────────────────────────────────────────");
+		lines.push("");
+		lines.push(`  Input:   ${fmtTokens(totalInput)}`);
+		lines.push(`  Output:  ${fmtTokens(totalOutput)}  (${outputTokPerSec} tok/s)`);
+		if (totalCacheRead > 0 || totalCacheWrite > 0) {
+			lines.push(
+				`  Cache:   ${fmtTokens(totalCacheRead)} read (${cacheHitRate}% hit) │ ${fmtTokens(totalCacheWrite)} write`,
+			);
+		}
+		if (totalCost > 0) lines.push(`  Cost:    $${totalCost.toFixed(4)}`);
+		if (totalEnergy > 0) {
+			lines.push(
+				`  Energy:  ${fmtEnergy({ energy_joules: totalEnergy, energy_kwh: totalEnergy / 3_600_000, duration_seconds: 0 })}`,
+			);
+		}
+		const totalToolOutput = t.tools.reduce((s, tool) => s + tool.outputSize, 0);
+		if (totalToolOutput > 0) lines.push(`  Tool output size: ${fmtBytes(totalToolOutput)}`);
 		lines.push("");
 
 		// ── Per-turn breakdown ──
 		if (t.turns.length > 0) {
-			lines.push("  ── Per Turn ──────────────────────────────────────────");
+			lines.push("  ── Per Turn ─────────────────────────────────────────────");
 			lines.push("");
 			for (const turn of t.turns) {
 				const turnTotal = (turn.end || t.promptEnd) - turn.start;
 				const turnLlm =
 					turn.requestStart != null && turn.requestEnd != null ? turn.requestEnd - turn.requestStart : 0;
-				const turnTool = turn.tools.reduce((s, t) => s + (t.end - t.start), 0);
+				const turnTool = turn.tools.reduce((s, tool) => s + (tool.end - tool.start), 0);
 				const turnOverhead = turnTotal - turnLlm - turnTool;
+
+				// Token throughput for this turn
+				const turnOutPerSec = turnLlm > 0 ? Math.round(turn.outputTokens / (turnLlm / 1000)) : 0;
+				const turnCacheRate =
+					turn.inputTokens > 0 ? Math.round((turn.cacheReadTokens / turn.inputTokens) * 100) : 0;
 
 				lines.push(`  Turn ${turn.index + 1}: ${fmt(turnTotal)}`);
 				lines.push(`    LLM: ${fmt(turnLlm)}${turn.requestTtfb ? ` (TTFB: ${fmt(turn.requestTtfb)})` : ""}`);
+				lines.push(
+					`    Tokens: ${fmtTokens(turn.inputTokens)} in │ ${fmtTokens(turn.outputTokens)} out (${turnOutPerSec} tok/s)`,
+				);
+				if (turn.cacheReadTokens > 0) {
+					lines.push(
+						`    Cache: ${fmtTokens(turn.cacheReadTokens)} read (${turnCacheRate}% hit) │ ${fmtTokens(turn.cacheWriteTokens)} write`,
+					);
+				}
 				lines.push(`    Tools: ${fmt(turnTool)} (${turn.tools.length} call${turn.tools.length !== 1 ? "s" : ""})`);
 				if (turnOverhead > 100) {
 					lines.push(`    Overhead: ${fmt(turnOverhead)}`);
 				}
 
-				// Per-tool detail for this turn
+				// Per-tool detail
 				if (turn.tools.length > 0) {
-					const toolGroups = new Map<string, { count: number; time: number; errors: number }>();
+					const toolGroups = new Map<
+						string,
+						{ count: number; time: number; errors: number; outputBytes: number }
+					>();
 					for (const tool of turn.tools) {
-						const g = toolGroups.get(tool.name) || { count: 0, time: 0, errors: 0 };
+						const g = toolGroups.get(tool.name) || { count: 0, time: 0, errors: 0, outputBytes: 0 };
 						g.count++;
 						g.time += tool.end - tool.start;
 						if (tool.isError) g.errors++;
+						g.outputBytes += tool.outputSize;
 						toolGroups.set(tool.name, g);
 					}
 					const parts = Array.from(toolGroups.entries())
 						.sort((a, b) => b[1].time - a[1].time)
-						.map(([name, g]) => `${name}×${g.count}: ${fmt(g.time)}${g.errors > 0 ? ` (${g.errors} err)` : ""}`);
+						.map(([name, g]) => {
+							let s = `${name}×${g.count}: ${fmt(g.time)}`;
+							if (g.outputBytes > 1024) s += ` (${fmtBytes(g.outputBytes)} out)`;
+							if (g.errors > 0) s += ` (${g.errors} err)`;
+							return s;
+						});
 					lines.push(`    [${parts.join(", ")}]`);
 				}
 				lines.push("");
@@ -299,20 +535,28 @@ export default function (pi: ExtensionAPI) {
 
 		// ── All-time tool summary ──
 		if (t.tools.length > 0) {
-			lines.push("  ── All Tool Calls ──────────────────────────────────");
+			lines.push("  ── All Tool Calls ───────────────────────────────────────");
 			lines.push("");
 			const toolGroups = new Map<
 				string,
-				{ count: number; totalTime: number; min: number; max: number; errors: number }
+				{ count: number; totalTime: number; min: number; max: number; errors: number; totalOutputBytes: number }
 			>();
 			for (const tool of t.tools) {
 				const elapsed = tool.end - tool.start;
-				const g = toolGroups.get(tool.name) || { count: 0, totalTime: 0, min: Infinity, max: 0, errors: 0 };
+				const g = toolGroups.get(tool.name) || {
+					count: 0,
+					totalTime: 0,
+					min: Infinity,
+					max: 0,
+					errors: 0,
+					totalOutputBytes: 0,
+				};
 				g.count++;
 				g.totalTime += elapsed;
 				g.min = Math.min(g.min, elapsed);
 				g.max = Math.max(g.max, elapsed);
 				if (tool.isError) g.errors++;
+				g.totalOutputBytes += tool.outputSize;
 				toolGroups.set(tool.name, g);
 			}
 
@@ -320,38 +564,297 @@ export default function (pi: ExtensionAPI) {
 			for (const [name, g] of toolGroups) {
 				const avg = g.totalTime / g.count;
 				const errStr = g.errors > 0 ? `  (${g.errors} err)` : "";
-				const barW = 12;
+				const outStr = g.totalOutputBytes > 1024 ? `  out ${fmtBytes(g.totalOutputBytes)}` : "";
 				lines.push(
-					`  ${name.padEnd(maxName)}  ${bar(g.totalTime, total, barW)}  total ${fmt(g.totalTime)}  avg ${fmt(avg)}  min ${fmt(g.min)}  max ${fmt(g.max)}  ×${g.count}${errStr}`,
+					`  ${name.padEnd(maxName)}  ${bar(g.totalTime, total, 12)}  total ${fmt(g.totalTime)}  avg ${fmt(avg)}  min ${fmt(g.min)}  max ${fmt(g.max)}  ×${g.count}${outStr}${errStr}`,
 				);
 			}
 			lines.push("");
 		}
 
-		// ── Request latency ──
+		// ── LLM Request details ──
 		if (t.requests.length > 0) {
-			lines.push("  ── LLM Requests ───────────────────────────────────");
+			lines.push("  ── LLM Requests ────────────────────────────────────────");
 			lines.push("");
 			for (let i = 0; i < t.requests.length; i++) {
 				const r = t.requests[i];
 				const dur = r.end - r.start;
+				const reqOutPerSec = dur > 0 ? Math.round(r.outputTokens / (dur / 1000)) : 0;
+				const cacheRate = r.inputTokens > 0 ? Math.round((r.cacheReadTokens / r.inputTokens) * 100) : 0;
 				const ttfbStr = r.ttfb != null ? `  TTFB: ${fmt(r.ttfb)}` : "";
-				lines.push(`  Request ${i + 1} (turn ${r.turnIndex + 1}): ${fmt(dur)}${ttfbStr}`);
+				const modelStr = r.responseModel && r.responseModel !== r.model ? `  (${r.responseModel})` : "";
+				const retryStr = r.retryCount > 0 ? `  ⚠ retry #${r.retryCount}` : "";
+				const rateLimitStr = r.wasRateLimited ? "  ⚠ rate-limited" : "";
+				const statusStr = r.status ? `  HTTP ${r.status}` : "";
+
+				lines.push(
+					`  Request ${i + 1} (turn ${r.turnIndex + 1}): ${fmt(dur)}${ttfbStr}${modelStr}${retryStr}${rateLimitStr}${statusStr}`,
+				);
+				lines.push(
+					`    ${fmtTokens(r.inputTokens)} in │ ${fmtTokens(r.outputTokens)} out (${reqOutPerSec} tok/s) │ cache ${cacheRate}% hit`,
+				);
+				if (r.costTotal > 0) lines.push(`    Cost: $${r.costTotal.toFixed(4)}`);
+				if (r.energy)
+					lines.push(`    Energy: ${fmtEnergy(r.energy)} (${r.energy.duration_seconds.toFixed(1)}s GPU)`);
+				if (r.diagnosticsCount > 0) lines.push(`    Diagnostics: ${r.diagnosticsCount}`);
 			}
 			const avgTtfb = t.requests.reduce((s, r) => s + (r.ttfb ?? 0), 0) / t.requests.length;
 			const avgDur = t.requests.reduce((s, r) => s + (r.end - r.start), 0) / t.requests.length;
 			lines.push("");
-			lines.push(`  Avg request: ${fmt(avgDur)}  Avg TTFB: ${fmt(avgTtfb)}`);
+			lines.push(`  Avg request: ${fmt(avgDur)}  Avg TTFB: ${fmt(avgTtfb)}  Avg out: ${outputTokPerSec} tok/s`);
+			lines.push("");
+		}
+
+		// ── Compaction events ──
+		if (t.compactions.length > 0) {
+			lines.push("  ── Compactions ─────────────────────────────────────────");
+			lines.push("");
+			for (const c of t.compactions) {
+				lines.push(
+					`  Compacted at ${new Date(c.timestamp).toISOString()}: ${fmtTokens(c.tokensBefore)} tokens before`,
+				);
+			}
+			lines.push("");
+		}
+
+		// ── Context growth ──
+		if (t.contextSizes.length > 1) {
+			lines.push("  ── Context Growth ───────────────────────────────────────");
+			lines.push("");
+			for (const cs of t.contextSizes) {
+				lines.push(`  Turn ${cs.turnIndex + 1}: ${cs.messageCount} messages`);
+			}
 			lines.push("");
 		}
 
 		return lines.join("\n");
 	}
 
-	// ── Commands ──
+	// ══════════════════════════════════════════════════════════════════
+	// Optimization Analysis
+	// ══════════════════════════════════════════════════════════════════
+
+	function formatOptimization(t: PromptTiming): string {
+		const total = t.promptEnd - t.promptStart;
+		if (total === 0) return "No timing data";
+
+		const llmTime = t.requests.reduce((s, r) => s + (r.end - r.start), 0);
+		const toolTime = t.tools.reduce((s, r) => s + (r.end - r.start), 0);
+		const totalInput = t.requests.reduce((s, r) => s + r.inputTokens, 0);
+		const totalOutput = t.requests.reduce((s, r) => s + r.outputTokens, 0);
+		const totalCacheRead = t.requests.reduce((s, r) => s + r.cacheReadTokens, 0);
+		const totalCacheWrite = t.requests.reduce((s, r) => s + r.cacheWriteTokens, 0);
+		const totalCost = t.requests.reduce((s, r) => s + r.costTotal, 0);
+		const totalEnergy = t.requests.reduce((s, r) => s + (r.energy?.energy_joules ?? 0), 0);
+		const cacheHitRate = totalInput > 0 ? Math.round((totalCacheRead / totalInput) * 100) : 0;
+		const outputTokPerSec = llmTime > 0 ? Math.round(totalOutput / (llmTime / 1000)) : 0;
+		const avgTtfb = t.requests.length > 0 ? t.requests.reduce((s, r) => s + (r.ttfb ?? 0), 0) / t.requests.length : 0;
+
+		const findings: { severity: "critical" | "warning" | "info"; icon: string; title: string; detail: string }[] = [];
+
+		// ── Context bloat ──
+		if (totalInput > 50_000 && cacheHitRate < 50) {
+			findings.push({
+				severity: "critical",
+				icon: "🔥",
+				title: "Large context with poor cache hit rate",
+				detail: `Sending ${fmtTokens(totalInput)} input tokens with only ${cacheHitRate}% cache hits. Each turn re-sends most tokens at full cost. Consider:\n    • Reduce tool output sizes (add truncation)\n    • Compact earlier to shrink context\n    • Structure prompts for cache alignment (static prefix, dynamic suffix)`,
+			});
+		} else if (totalInput > 100_000) {
+			findings.push({
+				severity: "warning",
+				icon: "⚠️",
+				title: "Very large context window",
+				detail: `${fmtTokens(totalInput)} input tokens per request. Even with ${cacheHitRate}% cache hits, this drives TTFB and cost. Consider compacting or reducing verbose tool output.`,
+			});
+		}
+
+		// ── Cache optimization ──
+		if (totalCacheWrite > 0 && cacheHitRate < 30 && totalInput > 10_000) {
+			findings.push({
+				severity: "warning",
+				icon: "💾",
+				title: "Low cache efficiency",
+				detail: `${fmtTokens(totalCacheWrite)} tokens written to cache but only ${cacheHitRate}% hit rate. Cache writes are wasted if subsequent turns re-read different prefixes. Ensure system prompt and early messages remain stable across turns.`,
+			});
+		}
+
+		// ── Tool output bloat ──
+		const largeToolOutputs = t.tools.filter((tool) => tool.outputSize > 10 * 1024);
+		if (largeToolOutputs.length > 0) {
+			const totalBloat = largeToolOutputs.reduce((s, tool) => s + tool.outputSize, 0);
+			const examples = largeToolOutputs.slice(0, 3).map((tool) => `${tool.name} (${fmtBytes(tool.outputSize)})`);
+			findings.push({
+				severity: "warning",
+				icon: "📦",
+				title: "Tool outputs inflating context",
+				detail: `${largeToolOutputs.length} tool call${largeToolOutputs.length > 1 ? "s" : ""} produced ${fmtBytes(totalBloat)} of output that gets fed back as input next turn: ${examples.join(", ")}\n    Consider: truncating output, using offset/limit on reads, or piping through grep/head.`,
+			});
+		}
+
+		// ── Slow TTFB ──
+		if (avgTtfb > 3000 && totalInput > 20_000) {
+			findings.push({
+				severity: "warning",
+				icon: "🐢",
+				title: "High TTFB — likely caused by large context",
+				detail: `Average TTFB: ${fmt(avgTtfb)}. With ${fmtTokens(totalInput)} input tokens, prefill is the bottleneck. Reducing context size will directly lower TTFB.`,
+			});
+		} else if (avgTtfb > 5000) {
+			findings.push({
+				severity: "warning",
+				icon: "🐢",
+				title: "High TTFB",
+				detail: `Average TTFB: ${fmt(avgTtfb)} even with moderate context. This may indicate provider-side queueing, model load, or network latency. Check model throughput metric.`,
+			});
+		}
+
+		// ── Low output throughput ──
+		if (outputTokPerSec > 0 && outputTokPerSec < 20 && totalOutput > 500) {
+			findings.push({
+				severity: "warning",
+				icon: "📝",
+				title: "Low output token throughput",
+				detail: `${outputTokPerSec} tok/s output. This may indicate the model is running on oversized weights, a loaded GPU, or a slow provider. Consider a smaller/faster model for routine tasks.`,
+			});
+		}
+
+		// ── LLM vs tool time imbalance ──
+		if (toolTime > llmTime && total > 5000) {
+			findings.push({
+				severity: "info",
+				icon: "🔧",
+				title: "Tool time exceeds LLM time",
+				detail: `${fmt(toolTime)} in tools vs ${fmt(llmTime)} in LLM. Slow tools dominate your latency. Profile individual tools to find optimization targets.`,
+			});
+		}
+
+		// ── Retries and rate limits ──
+		const retries = t.requests.filter((r) => r.retryCount > 0);
+		const rateLimits = t.requests.filter((r) => r.wasRateLimited);
+		if (rateLimits.length > 0) {
+			findings.push({
+				severity: "critical",
+				icon: "🚦",
+				title: "Rate limiting detected",
+				detail: `${rateLimits.length} request${rateLimits.length > 1 ? "s" : ""} hit rate limits. This adds retry latency and cost. Consider:\n    • Lower thinking level to reduce output tokens\n    • Use a model with higher rate limits\n    • Reduce parallel tool calls that trigger sub-requests`,
+			});
+		}
+		if (retries.length > 0) {
+			findings.push({
+				severity: "warning",
+				icon: "🔄",
+				title: "Request retries",
+				detail: `${retries.length} request${retries.length > 1 ? "s" : ""} required retries. Total retry overhead: ${fmt(retries.reduce((s, r) => s + r.retryCount, 0) * avgTtfb)}. Check provider diagnostics.`,
+			});
+		}
+
+		// ── Excessive turns ──
+		if (t.turns.length > 5) {
+			findings.push({
+				severity: "info",
+				icon: "🔁",
+				title: "Many turns per prompt",
+				detail: `${t.turns.length} turns for this prompt. Each turn sends the full context again. Consider prompting the model to batch tool calls or reduce round-trips.`,
+			});
+		}
+
+		// ── Compaction frequency ──
+		if (t.compactions.length > 1) {
+			findings.push({
+				severity: "info",
+				icon: "🗜",
+				title: "Frequent compaction",
+				detail: `${t.compactions.length} compactions during this prompt. Context is growing fast — likely from verbose tool output. Each compaction itself costs an LLM call.`,
+			});
+		}
+
+		// ── Energy per token ──
+		if (totalEnergy > 0 && totalOutput > 0) {
+			const joulesPerTok = totalEnergy / totalOutput;
+			if (joulesPerTok > 1.0) {
+				findings.push({
+					severity: "info",
+					icon: "⚡",
+					title: "High energy per output token",
+					detail: `${joulesPerTok.toFixed(2)} J/token. This is above baseline — GPU may not be power-optimized for this load. Check neuralwatt_agent Q-learning policy.`,
+				});
+			}
+		}
+
+		// ── Render ──
+		const lines: string[] = [];
+		lines.push("");
+		lines.push("╭──────────────────────────────────────────────────────────╮");
+		lines.push("│  OPTIMIZATION ANALYSIS                                    │");
+		lines.push("╰──────────────────────────────────────────────────────────╯");
+		lines.push("");
+
+		if (findings.length === 0) {
+			lines.push("  ✅ No obvious optimization targets detected.");
+			lines.push(
+				`     ${fmt(total)} total │ ${fmtTokens(totalInput)} in │ ${outputTokPerSec} tok/s out │ ${cacheHitRate}% cache hit`,
+			);
+			lines.push("");
+			return lines.join("\n");
+		}
+
+		// Sort by severity
+		const severityOrder = { critical: 0, warning: 1, info: 2 } as const;
+		findings.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+
+		for (const f of findings) {
+			lines.push(`  ${f.icon}  ${f.title} [${f.severity.toUpperCase()}]`);
+			for (const line of f.detail.split("\n")) {
+				lines.push(`     ${line}`);
+			}
+			lines.push("");
+		}
+
+		// ── Quick stats ──
+		lines.push("  ── Quick Stats ──────────────────────────────────────────");
+		lines.push("");
+		lines.push(`  Total time:    ${fmt(total)}`);
+		lines.push(`  LLM time:     ${fmt(llmTime)} (${pct(llmTime, total)})`);
+		lines.push(`  Tool time:     ${fmt(toolTime)} (${pct(toolTime, total)})`);
+		lines.push(`  Avg TTFB:     ${fmt(avgTtfb)}`);
+		lines.push(`  Out throughput: ${outputTokPerSec} tok/s`);
+		lines.push(`  Cache hit:     ${cacheHitRate}%`);
+		lines.push(`  Input tokens:  ${fmtTokens(totalInput)}`);
+		lines.push(`  Output tokens: ${fmtTokens(totalOutput)}`);
+		if (totalCost > 0) lines.push(`  Cost:          $${totalCost.toFixed(4)}`);
+		if (totalEnergy > 0)
+			lines.push(
+				`  Energy:        ${fmtEnergy({ energy_joules: totalEnergy, energy_kwh: totalEnergy / 3_600_000, duration_seconds: 0 })}`,
+			);
+		lines.push("");
+
+		// ── Top tool output contributors ──
+		if (t.tools.length > 0) {
+			const toolOutputs = [...t.tools]
+				.filter((tool) => tool.outputSize > 0)
+				.sort((a, b) => b.outputSize - a.outputSize)
+				.slice(0, 5);
+			if (toolOutputs.length > 0) {
+				lines.push("  ── Top Context Bloat Sources (tool output size) ────────");
+				lines.push("");
+				for (const tool of toolOutputs) {
+					const argsStr = tool.argsSummary ? ` — ${tool.argsSummary}` : "";
+					lines.push(`  ${fmtBytes(tool.outputSize).padStart(8)}  ${tool.name}${argsStr}`);
+				}
+				lines.push("");
+			}
+		}
+
+		return lines.join("\n");
+	}
+
+	// ══════════════════════════════════════════════════════════════════
+	// Commands
+	// ══════════════════════════════════════════════════════════════════
 
 	pi.registerCommand("timing", {
-		description: "Show timing breakdown (use 'full', 'reset', or 'watch')",
+		description: "Show timing breakdown (use 'full', 'opt', 'reset', 'watch', or 'footer')",
 		handler: async (args, ctx) => {
 			const arg = (args || "").trim().toLowerCase();
 
@@ -368,49 +871,66 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			if (arg === "footer" || arg === "footer-on") {
-				footerEnabled = true;
-				ctx.ui.setFooter((tui, theme, footerData) => {
-					const unsub = footerData.onBranchChange(() => tui.requestRender());
-					return {
-						dispose: unsub,
-						invalidate() {},
-						render(width: number): string[] {
-							if (!current || !footerEnabled) {
-								footerEnabled = false;
-								ctx.ui.setFooter(undefined);
-								return [];
-							}
-							const elapsed = Date.now() - current.promptStart;
-							const llmMs = current.requests.reduce((s, r) => s + (r.end || Date.now()) - r.start, 0);
-							const toolMs = current.tools.reduce((s, r) => s + (r.end - r.start), 0);
+			if (arg === "footer") {
+				footerEnabled = !footerEnabled;
+				if (footerEnabled) {
+					ctx.ui.setFooter((tui, theme, footerData) => {
+						const unsub = footerData.onBranchChange(() => tui.requestRender());
+						return {
+							dispose: unsub,
+							invalidate() {},
+							render(width: number): string[] {
+								if (!current) {
+									footerEnabled = false;
+									ctx.ui.setFooter(undefined);
+									return [];
+								}
+								const elapsed = Date.now() - current.promptStart;
+								const llmMs = current.requests.reduce((s, r) => s + (r.end || Date.now()) - r.start, 0);
+								const toolMs = current.tools.reduce((s, r) => s + (r.end - r.start), 0);
+								const totalIn = current.requests.reduce((s, r) => s + r.inputTokens, 0);
+								const totalOut = current.requests.reduce((s, r) => s + r.outputTokens, 0);
+								const outPerSec = llmMs > 0 ? Math.round(totalOut / (llmMs / 1000)) : 0;
+								const cacheRate =
+									totalIn > 0
+										? Math.round(
+												(current.requests.reduce((s, r) => s + r.cacheReadTokens, 0) / totalIn) * 100,
+											)
+										: 0;
+								const totalEnergy = current.requests.reduce((s, r) => s + (r.energy?.energy_joules ?? 0), 0);
 
-							const left = theme.fg("dim", `⏱ ${fmt(elapsed)}`);
-							const parts: string[] = [];
-							if (llmMs > 0) parts.push(`LLM ${fmt(llmMs)}`);
-							if (toolMs > 0) parts.push(`tools ${fmt(toolMs)}`);
-							const mid = parts.length > 0 ? theme.fg("dim", ` (${parts.join(", ")})`) : "";
-							const branch = footerData.getGitBranch();
-							const right = theme.fg("dim", `${ctx.model?.id || ""}${branch ? ` (${branch})` : ""}`);
-							const pad = " ".repeat(
-								Math.max(1, width - visibleWidth(left) - visibleWidth(mid) - visibleWidth(right)),
-							);
-							return [truncateToWidth(left + mid + pad + right, width)];
-						},
-					};
-				});
-				ctx.ui.notify("Timing footer enabled", "info");
+								const left = theme.fg("dim", `⏱ ${fmt(elapsed)}`);
+								const parts: string[] = [];
+								if (llmMs > 0) parts.push(`LLM ${fmt(llmMs)}`);
+								if (toolMs > 0) parts.push(`tools ${fmt(toolMs)}`);
+								if (outPerSec > 0) parts.push(`${outPerSec} tok/s`);
+								if (cacheRate > 0) parts.push(`cache ${cacheRate}%`);
+								const mid = parts.length > 0 ? theme.fg("dim", ` (${parts.join(", ")})`) : "";
+								const energyStr =
+									totalEnergy > 0
+										? `⚡${fmtEnergy({ energy_joules: totalEnergy, energy_kwh: 0, duration_seconds: 0 })}`
+										: "";
+								const branch = footerData.getGitBranch();
+								const right = theme.fg(
+									"dim",
+									`${energyStr}${ctx.model?.id || ""}${branch ? ` (${branch})` : ""}`,
+								);
+								const pad = " ".repeat(
+									Math.max(1, width - visibleWidth(left) - visibleWidth(mid) - visibleWidth(right)),
+								);
+								return [truncateToWidth(left + mid + pad + right, width)];
+							},
+						};
+					});
+					ctx.ui.notify("Timing footer enabled", "info");
+				} else {
+					ctx.ui.setFooter(undefined);
+					ctx.ui.notify("Timing footer disabled", "info");
+				}
 				return;
 			}
 
-			if (arg === "footer-off") {
-				footerEnabled = false;
-				ctx.ui.setFooter(undefined);
-				ctx.ui.notify("Timing footer disabled", "info");
-				return;
-			}
-
-			// Default: show summary or full
+			// Default: show summary, full, or opt
 			const source = current || history[history.length - 1];
 			if (!source) {
 				ctx.ui.notify("No timing data yet. Run a prompt first.", "warning");
@@ -418,8 +938,9 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			if (arg === "full") {
-				// Use notify for the full breakdown since it can be long
 				ctx.ui.notify(formatFull(source), "info");
+			} else if (arg === "opt") {
+				ctx.ui.notify(formatOptimization(source), "info");
 			} else {
 				ctx.ui.notify(formatSummary(source), "info");
 			}

--- a/packages/coding-agent/examples/extensions/timing-breakdown/index.ts
+++ b/packages/coding-agent/examples/extensions/timing-breakdown/index.ts
@@ -1,0 +1,428 @@
+/**
+ * Timing Breakdown Extension
+ *
+ * Tracks wall-clock time spent in LLM requests vs tool calls vs overhead,
+ * with per-tool and per-turn breakdowns.
+ *
+ * Commands:
+ *   /timing        — Show timing summary for the last prompt
+ *   /timing full   — Show detailed per-turn and per-tool breakdown
+ *   /timing reset  — Clear accumulated timing data
+ *   /timing watch  — Toggle auto-display after each agent_end
+ *
+ * Also shows a compact timing line in the footer that updates live.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+interface RequestTiming {
+	start: number; // Date.now() at before_provider_request
+	ttfb?: number; // ms to first byte (after_provider_response)
+	end: number; // Date.now() when assistant message_end fires
+	turnIndex: number;
+}
+
+interface ToolTiming {
+	toolCallId: string;
+	name: string;
+	start: number; // Date.now() at tool_execution_start
+	end: number; // Date.now() at tool_execution_end
+	isError: boolean;
+	turnIndex: number;
+}
+
+interface TurnTiming {
+	index: number;
+	start: number; // turn_start timestamp
+	end: number; // turn_end timestamp
+	requestStart?: number;
+	requestTtfb?: number;
+	requestEnd?: number;
+	tools: ToolTiming[];
+}
+
+interface PromptTiming {
+	promptStart: number; // agent_start
+	promptEnd: number; // agent_end
+	turns: TurnTiming[];
+	requests: RequestTiming[];
+	tools: ToolTiming[];
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function fmt(ms: number): string {
+	if (ms < 1000) return `${Math.round(ms)}ms`;
+	if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+	const mins = Math.floor(ms / 60_000);
+	const secs = Math.round((ms % 60_000) / 1000);
+	return `${mins}m${secs}s`;
+}
+
+function pct(part: number, whole: number): string {
+	if (whole === 0) return "0%";
+	return `${Math.round((part / whole) * 100)}%`;
+}
+
+function bar(part: number, whole: number, width = 20): string {
+	if (whole === 0) return " ".repeat(width);
+	const filled = Math.round((part / whole) * width);
+	return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+// ── Extension ───────────────────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+	let current: PromptTiming | null = null;
+	let history: PromptTiming[] = [];
+	let autoShow = false;
+	let footerEnabled = false;
+
+	// ── Accumulator for in-flight request tracking ──
+
+	// We track pending requests by turn to handle multi-turn flows
+	const pendingRequests = new Map<number, number>(); // turnIndex -> request start time
+	let currentTurnIndex = 0;
+
+	// ── Agent lifecycle ──
+
+	pi.on("agent_start", async () => {
+		current = {
+			promptStart: Date.now(),
+			promptEnd: 0,
+			turns: [],
+			requests: [],
+			tools: [],
+		};
+		currentTurnIndex = 0;
+		pendingRequests.clear();
+		if (footerEnabled) {
+			pi.sendUserMessage("/timing footer-on", { deliverAs: "followUp" });
+		}
+	});
+
+	pi.on("agent_end", async (_event, ctx) => {
+		if (!current) return;
+		current.promptEnd = Date.now();
+		history.push(current);
+
+		// Keep only last 20 prompts
+		if (history.length > 20) history = history.slice(-20);
+
+		if (autoShow) {
+			const summary = formatSummary(current);
+			ctx.ui.notify(summary, "info");
+		}
+	});
+
+	// ── Turn tracking ──
+
+	pi.on("turn_start", async (event) => {
+		if (!current) return;
+		currentTurnIndex = event.turnIndex ?? current.turns.length;
+		current.turns.push({
+			index: currentTurnIndex,
+			start: Date.now(),
+			end: 0,
+			tools: [],
+		});
+	});
+
+	pi.on("turn_end", async (_event) => {
+		if (!current) return;
+		const turn = current.turns.find((t) => t.index === currentTurnIndex);
+		if (turn) turn.end = Date.now();
+	});
+
+	// ── Provider request tracking ──
+
+	pi.on("before_provider_request", async () => {
+		if (!current) return;
+		const start = Date.now();
+		pendingRequests.set(currentTurnIndex, start);
+		current.requests.push({
+			start,
+			end: 0,
+			turnIndex: currentTurnIndex,
+		});
+	});
+
+	pi.on("after_provider_response", async () => {
+		if (!current) return;
+		const now = Date.now();
+		const req = [...current.requests].reverse().find((r) => r.end === 0);
+		if (req) {
+			req.ttfb = now - req.start;
+		}
+		// Update turn's request timing
+		const turn = current.turns.find((t) => t.index === req?.turnIndex);
+		if (turn && req) {
+			turn.requestStart = req.start;
+			turn.requestTtfb = req.ttfb;
+		}
+	});
+
+	pi.on("message_end", async (event) => {
+		if (!current) return;
+		if (event.message.role !== "assistant") return;
+		const now = Date.now();
+		// Close the most recent open request
+		const req = [...current.requests].reverse().find((r) => r.end === 0);
+		if (req) {
+			req.end = now;
+		}
+		// Update turn's request end
+		const turn = current.turns.find((t) => t.index === req?.turnIndex);
+		if (turn && req) {
+			turn.requestEnd = now;
+		}
+	});
+
+	// ── Tool execution tracking ──
+
+	pi.on("tool_execution_start", async (event) => {
+		if (!current) return;
+		current.tools.push({
+			toolCallId: event.toolCallId,
+			name: event.toolName,
+			start: Date.now(),
+			end: 0,
+			isError: false,
+			turnIndex: currentTurnIndex,
+		});
+		// Also push to the current turn
+		const turn = current.turns.find((t) => t.index === currentTurnIndex);
+		if (turn) {
+			turn.tools.push(current.tools[current.tools.length - 1]);
+		}
+	});
+
+	pi.on("tool_execution_end", async (event) => {
+		if (!current) return;
+		const t = current.tools.find((t) => t.toolCallId === event.toolCallId && t.end === 0);
+		if (t) {
+			t.end = Date.now();
+			t.isError = event.isError;
+		}
+	});
+
+	// ── Formatting ──
+
+	function formatSummary(t: PromptTiming): string {
+		const total = t.promptEnd - t.promptStart;
+		if (total === 0) return "No timing data";
+
+		const llmTime = t.requests.reduce((s, r) => s + (r.end - r.start), 0);
+		const toolTime = t.tools.reduce((s, r) => s + (r.end - r.start), 0);
+		const overhead = total - llmTime - toolTime;
+		const turns = t.turns.length;
+		const toolCalls = t.tools.length;
+
+		const lines: string[] = [];
+		lines.push(
+			`⏱  ${fmt(total)} total │ ${fmt(llmTime)} LLM (${pct(llmTime, total)}) │ ${fmt(toolTime)} tools (${pct(toolTime, total)}) │ ${fmt(overhead)} overhead (${pct(overhead, total)})`,
+		);
+		lines.push(`   ${turns} turn${turns !== 1 ? "s" : ""} │ ${toolCalls} tool call${toolCalls !== 1 ? "s" : ""}`);
+
+		if (t.requests.length > 0) {
+			const avgTtfb = t.requests.reduce((s, r) => s + (r.ttfb ?? 0), 0) / t.requests.length;
+			lines.push(`   TTFB: ${fmt(avgTtfb)} avg`);
+		}
+
+		return lines.join("\n");
+	}
+
+	function formatFull(t: PromptTiming): string {
+		const total = t.promptEnd - t.promptStart;
+		if (total === 0) return "No timing data";
+
+		const llmTime = t.requests.reduce((s, r) => s + (r.end - r.start), 0);
+		const toolTime = t.tools.reduce((s, r) => s + (r.end - r.start), 0);
+		const overhead = total - llmTime - toolTime;
+
+		const lines: string[] = [];
+
+		// ── Header: overall breakdown ──
+		lines.push("");
+		lines.push("╭─────────────────────────────────────────────────────────╮");
+		lines.push("│  TIMING BREAKDOWN                                       │");
+		lines.push("╰─────────────────────────────────────────────────────────╯");
+		lines.push("");
+		lines.push(`  Total: ${fmt(total)}`);
+		lines.push("");
+		lines.push(`  LLM requests  ${bar(llmTime, total)} ${fmt(llmTime)} (${pct(llmTime, total)})`);
+		lines.push(`  Tool calls     ${bar(toolTime, total)} ${fmt(toolTime)} (${pct(toolTime, total)})`);
+		lines.push(
+			`  Overhead       ${bar(Math.max(0, overhead), total)} ${fmt(Math.max(0, overhead))} (${pct(Math.max(0, overhead), total)})`,
+		);
+		lines.push("");
+
+		// ── Per-turn breakdown ──
+		if (t.turns.length > 0) {
+			lines.push("  ── Per Turn ──────────────────────────────────────────");
+			lines.push("");
+			for (const turn of t.turns) {
+				const turnTotal = (turn.end || t.promptEnd) - turn.start;
+				const turnLlm =
+					turn.requestStart != null && turn.requestEnd != null ? turn.requestEnd - turn.requestStart : 0;
+				const turnTool = turn.tools.reduce((s, t) => s + (t.end - t.start), 0);
+				const turnOverhead = turnTotal - turnLlm - turnTool;
+
+				lines.push(`  Turn ${turn.index + 1}: ${fmt(turnTotal)}`);
+				lines.push(`    LLM: ${fmt(turnLlm)}${turn.requestTtfb ? ` (TTFB: ${fmt(turn.requestTtfb)})` : ""}`);
+				lines.push(`    Tools: ${fmt(turnTool)} (${turn.tools.length} call${turn.tools.length !== 1 ? "s" : ""})`);
+				if (turnOverhead > 100) {
+					lines.push(`    Overhead: ${fmt(turnOverhead)}`);
+				}
+
+				// Per-tool detail for this turn
+				if (turn.tools.length > 0) {
+					const toolGroups = new Map<string, { count: number; time: number; errors: number }>();
+					for (const tool of turn.tools) {
+						const g = toolGroups.get(tool.name) || { count: 0, time: 0, errors: 0 };
+						g.count++;
+						g.time += tool.end - tool.start;
+						if (tool.isError) g.errors++;
+						toolGroups.set(tool.name, g);
+					}
+					const parts = Array.from(toolGroups.entries())
+						.sort((a, b) => b[1].time - a[1].time)
+						.map(([name, g]) => `${name}×${g.count}: ${fmt(g.time)}${g.errors > 0 ? ` (${g.errors} err)` : ""}`);
+					lines.push(`    [${parts.join(", ")}]`);
+				}
+				lines.push("");
+			}
+		}
+
+		// ── All-time tool summary ──
+		if (t.tools.length > 0) {
+			lines.push("  ── All Tool Calls ──────────────────────────────────");
+			lines.push("");
+			const toolGroups = new Map<
+				string,
+				{ count: number; totalTime: number; min: number; max: number; errors: number }
+			>();
+			for (const tool of t.tools) {
+				const elapsed = tool.end - tool.start;
+				const g = toolGroups.get(tool.name) || { count: 0, totalTime: 0, min: Infinity, max: 0, errors: 0 };
+				g.count++;
+				g.totalTime += elapsed;
+				g.min = Math.min(g.min, elapsed);
+				g.max = Math.max(g.max, elapsed);
+				if (tool.isError) g.errors++;
+				toolGroups.set(tool.name, g);
+			}
+
+			const maxName = Math.max(...Array.from(toolGroups.keys()).map((n) => n.length), 4);
+			for (const [name, g] of toolGroups) {
+				const avg = g.totalTime / g.count;
+				const errStr = g.errors > 0 ? `  (${g.errors} err)` : "";
+				const barW = 12;
+				lines.push(
+					`  ${name.padEnd(maxName)}  ${bar(g.totalTime, total, barW)}  total ${fmt(g.totalTime)}  avg ${fmt(avg)}  min ${fmt(g.min)}  max ${fmt(g.max)}  ×${g.count}${errStr}`,
+				);
+			}
+			lines.push("");
+		}
+
+		// ── Request latency ──
+		if (t.requests.length > 0) {
+			lines.push("  ── LLM Requests ───────────────────────────────────");
+			lines.push("");
+			for (let i = 0; i < t.requests.length; i++) {
+				const r = t.requests[i];
+				const dur = r.end - r.start;
+				const ttfbStr = r.ttfb != null ? `  TTFB: ${fmt(r.ttfb)}` : "";
+				lines.push(`  Request ${i + 1} (turn ${r.turnIndex + 1}): ${fmt(dur)}${ttfbStr}`);
+			}
+			const avgTtfb = t.requests.reduce((s, r) => s + (r.ttfb ?? 0), 0) / t.requests.length;
+			const avgDur = t.requests.reduce((s, r) => s + (r.end - r.start), 0) / t.requests.length;
+			lines.push("");
+			lines.push(`  Avg request: ${fmt(avgDur)}  Avg TTFB: ${fmt(avgTtfb)}`);
+			lines.push("");
+		}
+
+		return lines.join("\n");
+	}
+
+	// ── Commands ──
+
+	pi.registerCommand("timing", {
+		description: "Show timing breakdown (use 'full', 'reset', or 'watch')",
+		handler: async (args, ctx) => {
+			const arg = (args || "").trim().toLowerCase();
+
+			if (arg === "reset") {
+				current = null;
+				history = [];
+				ctx.ui.notify("Timing data cleared", "info");
+				return;
+			}
+
+			if (arg === "watch") {
+				autoShow = !autoShow;
+				ctx.ui.notify(`Auto timing: ${autoShow ? "ON" : "OFF"}`, "info");
+				return;
+			}
+
+			if (arg === "footer" || arg === "footer-on") {
+				footerEnabled = true;
+				ctx.ui.setFooter((tui, theme, footerData) => {
+					const unsub = footerData.onBranchChange(() => tui.requestRender());
+					return {
+						dispose: unsub,
+						invalidate() {},
+						render(width: number): string[] {
+							if (!current || !footerEnabled) {
+								footerEnabled = false;
+								ctx.ui.setFooter(undefined);
+								return [];
+							}
+							const elapsed = Date.now() - current.promptStart;
+							const llmMs = current.requests.reduce((s, r) => s + (r.end || Date.now()) - r.start, 0);
+							const toolMs = current.tools.reduce((s, r) => s + (r.end - r.start), 0);
+
+							const left = theme.fg("dim", `⏱ ${fmt(elapsed)}`);
+							const parts: string[] = [];
+							if (llmMs > 0) parts.push(`LLM ${fmt(llmMs)}`);
+							if (toolMs > 0) parts.push(`tools ${fmt(toolMs)}`);
+							const mid = parts.length > 0 ? theme.fg("dim", ` (${parts.join(", ")})`) : "";
+							const branch = footerData.getGitBranch();
+							const right = theme.fg("dim", `${ctx.model?.id || ""}${branch ? ` (${branch})` : ""}`);
+							const pad = " ".repeat(
+								Math.max(1, width - visibleWidth(left) - visibleWidth(mid) - visibleWidth(right)),
+							);
+							return [truncateToWidth(left + mid + pad + right, width)];
+						},
+					};
+				});
+				ctx.ui.notify("Timing footer enabled", "info");
+				return;
+			}
+
+			if (arg === "footer-off") {
+				footerEnabled = false;
+				ctx.ui.setFooter(undefined);
+				ctx.ui.notify("Timing footer disabled", "info");
+				return;
+			}
+
+			// Default: show summary or full
+			const source = current || history[history.length - 1];
+			if (!source) {
+				ctx.ui.notify("No timing data yet. Run a prompt first.", "warning");
+				return;
+			}
+
+			if (arg === "full") {
+				// Use notify for the full breakdown since it can be long
+				ctx.ui.notify(formatFull(source), "info");
+			} else {
+				ctx.ui.notify(formatSummary(source), "info");
+			}
+		},
+	});
+}

--- a/packages/coding-agent/examples/extensions/timing-breakdown/index.ts
+++ b/packages/coding-agent/examples/extensions/timing-breakdown/index.ts
@@ -399,6 +399,14 @@ export default function (pi: ExtensionAPI) {
 			`   ${t.turns.length} turn${t.turns.length !== 1 ? "s" : ""} │ ${t.tools.length} tool call${t.tools.length !== 1 ? "s" : ""} │ ${fmtTokens(totalInput)} in │ ${fmtTokens(totalOutput)} out │ ${outputTokPerSec > 0 ? `${outputTokPerSec} tok/s` : "—"} out`,
 		);
 
+		// LLM:tools ratio as a simplified fraction
+		const ratioA = Math.round(llmTime / 100);
+		const ratioB = Math.round(toolTime / 100);
+		const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
+		const g = gcd(ratioA, ratioB) || 1;
+		const ratioStr = ratioB === 0 ? `${ratioA / g}:0` : `${ratioA / g}:${ratioB / g}`;
+		lines.push(`   ${ratioStr} LLM:tools`);
+
 		if (totalCacheRead > 0 || totalCacheWrite > 0) {
 			lines.push(
 				`   Cache: ${fmtTokens(totalCacheRead)} read (${cacheHitRate}% hit) │ ${fmtTokens(totalCacheWrite)} write`,

--- a/scripts/analyze_efficiency.py
+++ b/scripts/analyze_efficiency.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""
+Pi Session Efficiency Analyzer
+
+Parses pi JSON-mode output and identifies specific tool calls and LLM requests
+that are inefficient — too slow, too verbose, producing bloated output, or
+wasting cache.
+
+Usage:
+  pi --mode json -p --no-session "your task" 2>/dev/null | python3 analyze_efficiency.py
+  pi --mode json -p --no-session "your task" 2>/dev/null > session.jsonl
+  python3 analyze_efficiency.py < session.jsonl
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class RequestInfo:
+    turn_index: int
+    start_ms: int
+    end_ms: int
+    model: str = ""
+    response_model: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    cost_total: float = 0.0
+    energy_joules: float = 0.0
+    energy_duration_s: float = 0.0
+    stop_reason: str = ""
+    diagnostics: list = field(default_factory=list)
+    request_index: int = 0
+    tool_calls_in_request: list = field(default_factory=list)
+
+    @property
+    def duration_ms(self) -> int:
+        return self.end_ms - self.start_ms
+
+
+@dataclass
+class ToolCallInfo:
+    turn_index: int
+    call_id: str = ""
+    name: str = ""
+    args: dict = field(default_factory=dict)
+    start_ms: int = 0  # timestamp of the assistant message_end that contains this toolCall
+    end_ms: int = 0    # timestamp of the toolResult message_end
+    output_chars: int = 0
+    is_error: bool = False
+
+    @property
+    def duration_ms(self) -> int:
+        return self.end_ms - self.start_ms
+
+
+@dataclass
+class TurnInfo:
+    index: int
+    start_ms: int = 0
+    end_ms: int = 0
+    requests: list = field(default_factory=list)
+    tool_calls: list = field(default_factory=list)
+
+
+@dataclass
+class SessionAnalysis:
+    session_id: str = ""
+    start_ms: int = 0
+    end_ms: int = 0
+    turns: list = field(default_factory=list)
+    requests: list = field(default_factory=list)
+    tool_calls: list = field(default_factory=list)
+
+    @property
+    def total_ms(self) -> int:
+        return self.end_ms - self.start_ms if self.end_ms and self.start_ms else 0
+
+    @property
+    def llm_ms(self) -> int:
+        return sum(r.duration_ms for r in self.requests)
+
+    @property
+    def tool_ms(self) -> int:
+        return sum(t.duration_ms for t in self.tool_calls)
+
+    @property
+    def overhead_ms(self) -> int:
+        return max(0, self.total_ms - self.llm_ms - self.tool_ms)
+
+    @property
+    def total_input_tokens(self) -> int:
+        return sum(r.input_tokens for r in self.requests)
+
+    @property
+    def total_output_tokens(self) -> int:
+        return sum(r.output_tokens for r in self.requests)
+
+    @property
+    def total_cache_read(self) -> int:
+        return sum(r.cache_read_tokens for r in self.requests)
+
+    @property
+    def total_cache_write(self) -> int:
+        return sum(r.cache_write_tokens for r in self.requests)
+
+    @property
+    def total_cost(self) -> float:
+        return sum(r.cost_total for r in self.requests)
+
+    @property
+    def total_energy_joules(self) -> float:
+        return sum(r.energy_joules for r in self.requests)
+
+
+def parse_session(lines) -> SessionAnalysis:
+    s = SessionAnalysis()
+    current_turn: Optional[TurnInfo] = None
+    request_counter = 0
+    # Track tool calls by their call ID, matching assistant toolCall → toolResult
+    pending_tool_calls = {}  # call_id → ToolCallInfo
+    # Track the last assistant message timestamp for tool start time inference
+    last_assistant_end_ms = 0
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        t = obj.get("type", "")
+
+        if t == "session":
+            s.session_id = obj.get("id", "")
+            ts_raw = obj.get("timestamp", 0)
+            s.start_ms = _to_ms(ts_raw)
+
+        elif t == "turn_start":
+            ti = obj.get("turnIndex", len(s.turns))
+            current_turn = TurnInfo(index=ti, start_ms=last_assistant_end_ms)
+            s.turns.append(current_turn)
+
+        elif t == "turn_end":
+            pass  # timestamp on turn_end is the last event's timestamp
+
+        elif t == "message_end":
+            msg = obj.get("message", {})
+            role = msg.get("role", "")
+            ts = _to_ms(msg.get("timestamp", 0))
+
+            if role == "assistant":
+                request_counter += 1
+                usage = msg.get("usage", {})
+                cost = usage.get("cost", {})
+                energy = msg.get("energy") or {}
+
+                ri = RequestInfo(
+                    turn_index=current_turn.index if current_turn else -1,
+                    start_ms=last_assistant_end_ms if last_assistant_end_ms else s.start_ms,
+                    end_ms=ts,
+                    model=msg.get("model", ""),
+                    response_model=msg.get("responseModel", ""),
+                    input_tokens=usage.get("input", 0),
+                    output_tokens=usage.get("output", 0),
+                    cache_read_tokens=usage.get("cacheRead", 0),
+                    cache_write_tokens=usage.get("cacheWrite", 0),
+                    cost_total=cost.get("total", 0) if isinstance(cost, dict) else 0,
+                    energy_joules=energy.get("energy_joules", 0),
+                    energy_duration_s=energy.get("duration_seconds", 0),
+                    stop_reason=msg.get("stopReason", ""),
+                    diagnostics=msg.get("diagnostics", []),
+                    request_index=request_counter,
+                )
+                s.requests.append(ri)
+                if current_turn:
+                    current_turn.requests.append(ri)
+
+                # Extract tool calls embedded in this assistant message
+                for content in msg.get("content", []):
+                    if content.get("type") == "toolCall":
+                        tcid = content.get("id", "")
+                        tc = ToolCallInfo(
+                            turn_index=current_turn.index if current_turn else -1,
+                            call_id=tcid,
+                            name=content.get("name", ""),
+                            args=content.get("arguments", {}),
+                            start_ms=ts,  # tool starts when assistant finishes
+                            end_ms=ts,
+                        )
+                        pending_tool_calls[tcid] = tc
+                        s.tool_calls.append(tc)
+                        if current_turn:
+                            current_turn.tool_calls.append(tc)
+                        ri.tool_calls_in_request.append(tcid)
+
+                last_assistant_end_ms = ts
+
+                if current_turn:
+                    current_turn.end_ms = ts
+
+            elif role == "toolResult":
+                tcid = msg.get("toolCallId", "")
+                content_list = msg.get("content", [])
+                size = sum(len(c.get("text", "")) for c in content_list if c.get("type") == "text")
+
+                if tcid in pending_tool_calls:
+                    pending_tool_calls[tcid].end_ms = ts
+                    pending_tool_calls[tcid].output_chars = size
+                    pending_tool_calls[tcid].is_error = msg.get("isError", False)
+                    pending_tool_calls[tcid].turn_index = current_turn.index if current_turn else -1
+
+                # Update last assistant end for next request timing
+                last_assistant_end_ms = ts
+
+            elif role == "user":
+                if s.start_ms == 0 and ts:
+                    s.start_ms = ts
+                last_assistant_end_ms = ts
+
+        elif t == "agent_end":
+            # Use the last event timestamp
+            if s.requests:
+                s.end_ms = s.requests[-1].end_ms
+            else:
+                s.end_ms = s.start_ms
+
+    # Compute overall end from last request
+    if not s.end_ms and s.requests:
+        s.end_ms = s.requests[-1].end_ms
+
+    # Compute turn starts from their first request
+    for turn in s.turns:
+        if turn.requests:
+            turn.start_ms = turn.start_ms or turn.requests[0].start_ms
+            turn.end_ms = turn.end_ms or turn.requests[-1].end_ms
+
+    return s
+
+
+def _to_ms(ts) -> int:
+    """Convert timestamp to milliseconds. Handles int (Unix ms), float, or ISO string."""
+    if isinstance(ts, (int, float)):
+        return int(ts)
+    if isinstance(ts, str):
+        try:
+            from datetime import datetime
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            return int(dt.timestamp() * 1000)
+        except (ValueError, OSError):
+            return 0
+    return 0
+
+
+def fmt_ms(ms: int) -> str:
+    if ms < 1000:
+        return f"{ms}ms"
+    if ms < 60_000:
+        return f"{ms / 1000:.1f}s"
+    mins = ms // 60_000
+    secs = (ms % 60_000) / 1000
+    return f"{mins}m{secs:.0f}s"
+
+
+def fmt_tokens(n: int) -> str:
+    if n < 1000:
+        return f"{n}"
+    if n < 1_000_000:
+        return f"{n / 1000:.1f}k"
+    return f"{n / 1_000_000:.2f}M"
+
+
+def fmt_bytes(b: int) -> str:
+    if b < 1024:
+        return f"{b}B"
+    if b < 1024 * 1024:
+        return f"{b / 1024:.1f}KB"
+    return f"{b / (1024 * 1024):.1f}MB"
+
+
+def fmt_joules(j: float) -> str:
+    if j < 1:
+        return f"{j * 1000:.0f}mJ"
+    if j < 1000:
+        return f"{j:.1f}J"
+    return f"{j / 1000:.2f}kJ"
+
+
+def analyze(s: SessionAnalysis) -> str:
+    lines: list[str] = []
+    total = s.total_ms
+    llm = s.llm_ms
+    tools = s.tool_ms
+    overhead = s.overhead_ms
+
+    # Header
+    lines.append("")
+    lines.append("=" * 72)
+    lines.append("  EFFICIENCY ANALYSIS REPORT")
+    lines.append("=" * 72)
+    lines.append("")
+
+    # ── Overall ──
+    lines.append("── Overall ────────────────────────────────────────────────────")
+    lines.append("")
+    lines.append(f"  Wall clock:     {fmt_ms(total)}")
+    lines.append(f"  LLM time:       {fmt_ms(llm)} ({100 * llm // total if total else 0}%)")
+    lines.append(f"  Tool time:      {fmt_ms(tools)} ({100 * tools // total if total else 0}%)")
+    lines.append(f"  Overhead:       {fmt_ms(overhead)} ({100 * overhead // total if total else 0}%)")
+    lines.append(f"  Turns:          {len(s.turns)}")
+    lines.append(f"  Tool calls:     {len(s.tool_calls)}")
+    lines.append(f"  Input tokens:   {fmt_tokens(s.total_input_tokens)} (across all requests)")
+    lines.append(f"  Output tokens:  {fmt_tokens(s.total_output_tokens)}")
+    out_per_sec = s.total_output_tokens / (llm / 1000) if llm > 0 else 0
+    lines.append(f"  Out throughput: {out_per_sec:.0f} tok/s")
+    total_context_tokens = s.total_input_tokens + s.total_cache_read
+    cache_hit = (s.total_cache_read / total_context_tokens * 100) if total_context_tokens > 0 else 0
+    lines.append(f"  Cache hit rate: {cache_hit:.0f}%")
+    lines.append(f"  Cache read:     {fmt_tokens(s.total_cache_read)}")
+    lines.append(f"  Cache write:    {fmt_tokens(s.total_cache_write)}")
+    lines.append(f"  Cost:           ${s.total_cost:.4f}")
+    if s.total_energy_joules > 0:
+        lines.append(f"  Energy:         {fmt_joules(s.total_energy_joules)}")
+    lines.append("")
+
+    # ── Per-request breakdown ──
+    lines.append("── LLM Requests (ranked by inefficiency) ──────────────────────")
+    lines.append("")
+
+    req_scores = []
+    for i, r in enumerate(s.requests):
+        issues = []
+        dur_ms = r.duration_ms
+        score = 0
+
+        # High context with low cache
+        total_ctx = r.input_tokens + r.cache_read_tokens
+        cache_pct = (r.cache_read_tokens / total_ctx * 100) if total_ctx > 0 else 0
+        # Only warn on cache for requests with substantial context
+        if total_ctx > 5_000:
+            if cache_pct < 30:
+                issues.append(f"LOW CACHE ({cache_pct:.0f}% of {fmt_tokens(total_ctx)} context from cache, {fmt_tokens(r.input_tokens)} new tokens)")
+                score += 30
+            elif cache_pct < 60:
+                issues.append(f"moderate cache ({cache_pct:.0f}% of {fmt_tokens(total_ctx)} context from cache)")
+                score += 10
+        elif r.input_tokens > 50_000:
+            issues.append(f"HUGE CONTEXT ({fmt_tokens(r.input_tokens)} new input tokens)")
+            score += 25
+        elif r.input_tokens > 10_000 and r.cache_read_tokens == 0:
+            issues.append(f"NO CACHE on {fmt_tokens(r.input_tokens)} input — all tokens billed at full price")
+            score += 20
+
+        # Low output throughput
+        if dur_ms > 0:
+            tps = r.output_tokens / (dur_ms / 1000)
+            if tps < 15 and r.output_tokens > 100:
+                issues.append(f"slow generation ({tps:.0f} tok/s)")
+                score += 20
+            elif tps < 30 and r.output_tokens > 500:
+                issues.append(f"moderate generation ({tps:.0f} tok/s)")
+                score += 10
+
+        # High GPU energy per token
+        if r.energy_joules > 0 and r.output_tokens > 0:
+            jpt = r.energy_joules / r.output_tokens
+            if jpt > 2.0:
+                issues.append(f"high energy/token ({jpt:.2f} J/tok)")
+                score += 15
+
+        # Diagnostics / errors
+        if r.diagnostics:
+            issues.append(f"{len(r.diagnostics)} diagnostics")
+            score += 10
+
+        # Excessive output tokens
+        if r.output_tokens > 2000:
+            issues.append(f"verbose output ({fmt_tokens(r.output_tokens)})")
+            score += 5
+
+        # Stop reason
+        if r.stop_reason == "length":
+            issues.append("HIT LENGTH LIMIT — truncated output")
+            score += 25
+
+        # Input token spike (this request's input >> previous request's input)
+        if i > 0:
+            prev_input = s.requests[i - 1].input_tokens
+            if r.input_tokens > prev_input * 2 and prev_input > 0:
+                delta = r.input_tokens - prev_input
+                issues.append(f"INPUT SPIKE +{fmt_tokens(delta)} tokens from prev request (tool output bloat?)")
+                score += 15
+
+        req_scores.append((score, i, issues))
+
+    req_scores.sort(key=lambda x: -x[0])
+
+    for score, i, issues in req_scores:
+        r = s.requests[i]
+        dur_ms = r.duration_ms
+        tps = r.output_tokens / (dur_ms / 1000) if dur_ms > 0 else 0
+        cache_pct = (r.cache_read_tokens / (r.input_tokens + r.cache_read_tokens) * 100) if (r.input_tokens + r.cache_read_tokens) > 0 else 0
+
+        if score == 0:
+            marker = "✓"
+        elif score < 15:
+            marker = "·"
+        elif score < 30:
+            marker = "⚠"
+        else:
+            marker = "🔥"
+
+        lines.append(f"  {marker} Request {i + 1} (turn {r.turn_index + 1}): {fmt_ms(dur_ms)} | "
+                      f"{fmt_tokens(r.input_tokens)} in | {fmt_tokens(r.output_tokens)} out | "
+                      f"{tps:.0f} tok/s | cache {cache_pct:.0f}% | ${r.cost_total:.4f}")
+        if r.response_model and r.response_model != r.model:
+            lines.append(f"    Routed: {r.model} → {r.response_model}")
+        if r.energy_joules > 0:
+            lines.append(f"    Energy: {fmt_joules(r.energy_joules)} ({r.energy_duration_s:.1f}s GPU)")
+        # Show tool calls spawned
+        if r.tool_calls_in_request:
+            tc_names = []
+            for tcid in r.tool_calls_in_request:
+                tc = next((t for t in s.tool_calls if t.call_id == tcid), None)
+                if tc:
+                    tc_names.append(tc.name)
+            if tc_names:
+                lines.append(f"    Tool calls: {', '.join(tc_names)}")
+        for issue in issues:
+            lines.append(f"    → {issue}")
+        lines.append("")
+
+    # ── Tool calls ranked by inefficiency ──
+    lines.append("── Tool Calls (ranked by inefficiency) ────────────────────────")
+    lines.append("")
+
+    tool_scores = []
+    for i, tc in enumerate(s.tool_calls):
+        dur_ms = tc.duration_ms
+        issues = []
+        score = 0
+
+        # Bloated output — #1 context bloat source
+        if tc.output_chars > 20_000:
+            issues.append(f"HUGE OUTPUT ({fmt_bytes(tc.output_chars)}) — inflates next LLM request")
+            score += 30
+        elif tc.output_chars > 5_000:
+            issues.append(f"large output ({tc.output_chars:,} chars)")
+            score += 15
+        elif tc.output_chars > 2_000:
+            issues.append(f"moderate output ({tc.output_chars:,} chars)")
+            score += 5
+
+        # Slow execution
+        if dur_ms > 5000:
+            issues.append(f"slow ({fmt_ms(dur_ms)})")
+            score += 15
+        elif dur_ms > 2000:
+            issues.append(f"moderate ({fmt_ms(dur_ms)})")
+            score += 5
+
+        # Read without offset/limit
+        if tc.name == "read" and tc.args:
+            has_offset = tc.args.get("offset") is not None
+            has_limit = tc.args.get("limit") is not None
+            if not has_offset and not has_limit and tc.output_chars > 3000:
+                issues.append("full-file read (no offset/limit) — likely read more than needed")
+                score += 10
+
+        # Bash that could be more targeted
+        if tc.name == "bash" and tc.args:
+            cmd = str(tc.args.get("command", ""))
+            if "cat " in cmd and tc.output_chars > 2000:
+                issues.append("'cat' in bash — consider 'head' or 'grep' to limit output")
+                score += 8
+            # Long-running command
+            if dur_ms > 3000:
+                issues.append(f"long-running command: {cmd[:60]}")
+
+        # Write with huge content
+        if tc.name == "write" and tc.args:
+            content = str(tc.args.get("content", ""))
+            lines_count = content.count("\n") + 1
+            if lines_count > 100:
+                issues.append(f"large write ({lines_count} lines) — could use edit for targeted changes")
+                score += 5
+
+        # Edit with many replacements
+        if tc.name == "edit" and tc.args:
+            edits = tc.args.get("edits", [])
+            if isinstance(edits, list) and len(edits) > 3:
+                issues.append(f"many edits ({len(edits)}) — consider whether all are needed in one call")
+
+        tool_scores.append((score, i, issues))
+
+    tool_scores.sort(key=lambda x: -x[0])
+
+    for score, i, issues in tool_scores:
+        tc = s.tool_calls[i]
+
+        if score == 0:
+            marker = "✓"
+        elif score < 15:
+            marker = "·"
+        elif score < 30:
+            marker = "⚠"
+        else:
+            marker = "🔥"
+
+        # Build arg summary
+        arg_summary = ""
+        if tc.name == "bash":
+            cmd = str(tc.args.get("command", ""))[:70]
+            arg_summary = f"$ {cmd}"
+        elif tc.name == "read":
+            p = tc.args.get("file_path") or tc.args.get("path") or ""
+            offset = tc.args.get("offset")
+            limit = tc.args.get("limit")
+            arg_summary = p
+            if offset or limit:
+                arg_summary += f" (offset={offset}, limit={limit})"
+        elif tc.name == "write":
+            p = tc.args.get("file_path") or tc.args.get("path") or ""
+            arg_summary = p
+        elif tc.name == "edit":
+            p = tc.args.get("file_path") or tc.args.get("path") or ""
+            arg_summary = p
+
+        out_str = f" | {tc.output_chars:,} chars" if tc.output_chars > 500 else ""
+        lines.append(f"  {marker} {tc.name} ({fmt_ms(tc.duration_ms)}{out_str}) [turn {tc.turn_index + 1}]")
+        if arg_summary:
+            lines.append(f"    {arg_summary}")
+        for issue in issues:
+            lines.append(f"    → {issue}")
+        lines.append("")
+
+    # ── Context bloat analysis ──
+    lines.append("── Context Bloat Analysis ─────────────────────────────────────")
+    lines.append("")
+
+    total_tool_output = sum(tc.output_chars for tc in s.tool_calls)
+    lines.append(f"  Total tool output:       {fmt_bytes(total_tool_output)}")
+
+    # Per-tool breakdown
+    tool_types: dict[str, dict] = {}
+    for tc in s.tool_calls:
+        if tc.name not in tool_types:
+            tool_types[tc.name] = {"count": 0, "total_output": 0, "total_ms": 0, "max_output": 0}
+        tool_types[tc.name]["count"] += 1
+        tool_types[tc.name]["total_output"] += tc.output_chars
+        tool_types[tc.name]["total_ms"] += tc.duration_ms
+        tool_types[tc.name]["max_output"] = max(tool_types[tc.name]["max_output"], tc.output_chars)
+
+    lines.append("")
+    lines.append(f"  {'Tool':<10} {'Calls':>5} {'Total out':>10} {'Max out':>10} {'Time':>10}")
+    lines.append(f"  {'─' * 10} {'─' * 5} {'─' * 10} {'─' * 10} {'─' * 10}")
+    for name, info in sorted(tool_types.items(), key=lambda x: -x[1]["total_output"]):
+        lines.append(
+            f"  {name:<10} {info['count']:>5} {fmt_bytes(info['total_output']):>10} {fmt_bytes(info['max_output']):>10} {fmt_ms(info['total_ms']):>10}"
+        )
+
+    # Tool output as % of input tokens
+    lines.append("")
+    if s.requests and total_tool_output > 0:
+        tool_output_tokens_est = total_tool_output / 4
+        pct_of_input = (tool_output_tokens_est / s.total_input_tokens * 100) if s.total_input_tokens > 0 else 0
+        lines.append(f"  Tool output as % of total input: ~{pct_of_input:.0f}%")
+        lines.append(f"  (estimated: {fmt_tokens(int(tool_output_tokens_est))} of {fmt_tokens(s.total_input_tokens)} input tokens)")
+    lines.append("")
+
+    # ── Per-turn context growth ──
+    lines.append("── Per-Turn Context Growth ─────────────────────────────────────")
+    lines.append("")
+
+    cumulative_tool_output = 0
+    for turn in s.turns:
+        turn_tool_output = sum(tc.output_chars for tc in turn.tool_calls)
+        cumulative_tool_output += turn_tool_output
+
+        turn_input = sum(r.input_tokens for r in turn.requests)
+        turn_output_tokens = sum(r.output_tokens for r in turn.requests)
+        turn_cache = sum(r.cache_read_tokens for r in turn.requests)
+        turn_total_ctx = turn_input + turn_cache
+        turn_cache_pct = (turn_cache / turn_total_ctx * 100) if turn_total_ctx > 0 else 0
+        turn_energy = sum(r.energy_joules for r in turn.requests)
+        turn_cost = sum(r.cost_total for r in turn.requests)
+        turn_dur = sum(r.duration_ms for r in turn.requests)
+
+        tool_names = [tc.name for tc in turn.tool_calls]
+        tools_str = ", ".join(tool_names) if tool_names else "none"
+
+        lines.append(
+            f"  Turn {turn.index + 1}: "
+            f"{fmt_ms(turn_dur)} LLM │ "
+            f"{fmt_tokens(turn_input)} in │ "
+            f"{fmt_tokens(turn_output_tokens)} out │ "
+            f"cache {turn_cache_pct:.0f}% │ "
+            f"tool out {fmt_bytes(turn_tool_output)} │ "
+            f"cumul {fmt_bytes(cumulative_tool_output)} │ "
+            f"${turn_cost:.4f}"
+        )
+        lines.append(
+            f"           "
+            f"tools: [{tools_str}]"
+        )
+
+        # Show input token spike
+        if turn.index > 0:
+            prev_turn = s.turns[turn.index - 1] if turn.index - 1 < len(s.turns) else None
+            if prev_turn:
+                prev_input = sum(r.input_tokens for r in prev_turn.requests)
+                if turn_input > prev_input * 1.5 and prev_input > 0:
+                    delta = turn_input - prev_input
+                    lines.append(
+                        f"           ⚠ INPUT SPIKE +{fmt_tokens(delta)} from prev turn"
+                    )
+    lines.append("")
+
+    # ── Actionable recommendations ──
+    lines.append("── Actionable Recommendations ──────────────────────────────────")
+    lines.append("")
+
+    recs = []
+
+    big_outputs = [tc for tc in s.tool_calls if tc.output_chars > 10_000]
+    if big_outputs:
+        examples = [(tc.name, tc.output_chars) for tc in sorted(big_outputs, key=lambda x: -x.output_chars)[:3]]
+        ex_str = ", ".join(f"{n} ({fmt_bytes(s)})" for n, s in examples)
+        recs.append(("CRITICAL", f"Reduce tool output size: {ex_str}. These outputs get fed back as input tokens on every subsequent LLM call, compounding cost and latency.", "Add truncation, use head/grep for bash, offset/limit for reads."))
+
+    if cache_hit < 60 and total_context_tokens > 5000:
+        recs.append(("HIGH", f"Improve cache hit rate ({cache_hit:.0f}%). Low cache means paying full input price each turn.", "Ensure stable system prompt prefix. Minimize context mutations between turns. Compact earlier."))
+
+    full_reads = [tc for tc in s.tool_calls if tc.name == "read" and tc.args.get("offset") is None and tc.output_chars > 3000]
+    if full_reads:
+        recs.append(("MEDIUM", f"{len(full_reads)} full-file read(s) without offset/limit produced large output.", "Use offset/limit to read only needed sections, or grep first to find relevant lines."))
+
+    cat_bash = [tc for tc in s.tool_calls if tc.name == "bash" and "cat " in str(tc.args.get("command", ""))]
+    if cat_bash:
+        recs.append(("MEDIUM", f"{len(cat_bash)} bash call(s) use 'cat'.", "Replace with 'head -N', 'grep', or the read tool with offset/limit."))
+
+    if len(s.turns) > 4:
+        recs.append(("MEDIUM", f"{len(s.turns)} turns. Each turn re-sends the full context.", "Encourage the model to batch tool calls or be more targeted to reduce round-trips."))
+
+    if out_per_sec < 20 and s.total_output_tokens > 500:
+        recs.append(("HIGH", f"Output throughput is {out_per_sec:.0f} tok/s.", "This may indicate a loaded GPU or oversized model. Consider a smaller/faster model for routine tasks."))
+
+    if s.total_energy_joules > 0 and s.total_output_tokens > 0:
+        jpt = s.total_energy_joules / s.total_output_tokens
+        if jpt > 1.5:
+            recs.append(("MEDIUM", f"Energy efficiency: {jpt:.2f} J/output token. Above baseline.", "Check neuralwatt_agent Q-learning policy is active and GPU power state is optimized."))
+
+    # Check for input token growth between turns
+    inputs = [sum(r.input_tokens for r in turn.requests) for turn in s.turns]
+    if len(inputs) >= 2 and inputs[-1] > inputs[0] * 3:
+        growth = inputs[-1] - inputs[0]
+        recs.append(("HIGH", f"Context grew by {fmt_tokens(growth)} over {len(s.turns)} turns ({fmt_tokens(inputs[0])} → {fmt_tokens(inputs[-1])}).", "Tool output is likely accumulating in context. Add truncation or compact earlier."))
+
+    if not recs:
+        recs.append(("INFO", "No major inefficiencies detected.", ""))
+
+    for severity, problem, solution in recs:
+        icon = {"CRITICAL": "🔥", "HIGH": "⚠️", "MEDIUM": "💡", "INFO": "✅"}.get(severity, "·")
+        lines.append(f"  {icon} [{severity}]")
+        lines.append(f"     Problem: {problem}")
+        if solution:
+            lines.append(f"     Fix:     {solution}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    lines = sys.stdin.readlines()
+    s = parse_session(lines)
+    print(analyze(s))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a pi extension that tracks wall-clock time spent in LLM requests vs tool calls vs overhead
- Provides `/timing` (summary), `/timing full` (detailed per-turn/per-tool breakdown), `/timing watch` (auto-display), `/timing footer` (live footer), and `/timing reset` commands
- Uses pi extension hooks: `agent_start/end`, `turn_start/end`, `before_provider_request`, `after_provider_response`, `message_end`, `tool_execution_start/end`
- Installed at `~/.pi/agent/extensions/timing-breakdown/` via symlink to this tracked copy

## Test plan

- [x] TypeScript transpiles cleanly
- [x] Pre-commit checks pass (biome, tsgo, pinned deps, shrinkwrap)
- [x] Extension auto-discovered by pi from `~/.pi/agent/extensions/`
- [x] `/timing` command renders summary after a prompt
